### PR TITLE
Add VocaDB translations to EditTranslations component

### DIFF
--- a/packages/jukebox/src/components/dashboard/musicFilesDetails/LyricsEditDialog.tsx
+++ b/packages/jukebox/src/components/dashboard/musicFilesDetails/LyricsEditDialog.tsx
@@ -259,7 +259,7 @@ export default function LyricsEditDialog({
             <TaggingLyrics lyrics={lrcx} setLyrics={setLrcx} fileId={fileId} />
           </TabPanel>
           <TabPanel value="translation">
-            <EditTranslations lyrics={lrcx} setLyrics={setLrcx} />
+            <EditTranslations lyrics={lrcx} setLyrics={setLrcx} songId={songId} />
           </TabPanel>
           <TabPanel value="furigana">
             <EditFurigana


### PR DESCRIPTION
Add a row of buttons to import translations from VocaDB in `EditTranslations.tsx`.

* Import `VocaDBLyricsEntry` from `../../../../graphql/LyricsProvidersResolver`.
* Add a new state `vocaDBTranslations` to store translations from VocaDB.
* Add a new function `fetchVocaDBTranslations` to fetch translations from VocaDB.
* Add a row of buttons to import translations from VocaDB.
* Use @mui/material/Tooltip for button tooltip.
* Use `useQuery` to get VocaDB translations.
* Pass `songId` as a parameter to the component.
* Replace the state const [vocaDBTranslations, setVocaDBTranslations] with a `useQuery` usage.
* Add a function to import the language using the specified procedure.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/blueset/project-lyricova/pull/133?shareId=10ec5b60-dffa-43e6-82e1-9b6aa770058e).