### PR TITLE
refactor(jukebox): stabilize lyrics animation timing

### DIFF
--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -50,3 +50,23 @@ jobs:
 
       - name: Type-check (tsgo — TypeScript 7 native preview)
         run: npm run typecheck:native
+
+  browser-tests:
+    name: Lyrics animations (Chromium + Firefox)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium firefox
+
+      - name: Run jukebox browser tests
+        run: npm run test:browser -w @lyricova/jukebox

--- a/docs/development-and-build.md
+++ b/docs/development-and-build.md
@@ -181,6 +181,9 @@ Know these so you don't hunt for "missing" files or commit generated output:
 No new steps. Edit, and let `tsc -w` / `next dev` recompile. Validate with the
 per-package commands in [§6](#6-verification).
 
+For media-synchronized jukebox lyrics, follow the lifecycle and timing rules in
+[Jukebox animation timing](./jukebox-animation-timing.md).
+
 ### 5.2 GraphQL — **client** documents (queries/mutations/subscriptions)
 
 Anywhere in `components`, `jukebox`, or `lyricova`:
@@ -315,12 +318,12 @@ npm run typecheck:native  # turbo run typecheck:native (tsgo / TS 7 preview)
 npm run test              # turbo run test            (jest)
 ```
 
-| Package                                | Type-check                          | Lint           | Test              | Schema                |
-| -------------------------------------- | ----------------------------------- | -------------- | ----------------- | --------------------- |
-| `@lyricova/api`                        | `npm run typecheck` (or `build:ts`) | `npm run lint` | `npm test` (jest) | `npm run pothos:emit` |
-| `@lyricova/components`                 | `npm run typecheck`                 | `npm run lint` | —                 | —                     |
-| `@lyricova/jukebox`                    | `npm run typecheck`                 | `npm run lint` | `npm test`        | —                     |
-| `@lyricova/blog` (`packages/lyricova`) | `npm run typecheck`                 | `npm run lint` | `npm test`        | —                     |
+| Package                                | Type-check                          | Lint           | Test                               | Schema                |
+| -------------------------------------- | ----------------------------------- | -------------- | ---------------------------------- | --------------------- |
+| `@lyricova/api`                        | `npm run typecheck` (or `build:ts`) | `npm run lint` | `npm test` (jest)                  | `npm run pothos:emit` |
+| `@lyricova/components`                 | `npm run typecheck`                 | `npm run lint` | —                                  | —                     |
+| `@lyricova/jukebox`                    | `npm run typecheck`                 | `npm run lint` | `npm test`; `npm run test:browser` | —                     |
+| `@lyricova/blog` (`packages/lyricova`) | `npm run typecheck`                 | `npm run lint` | `npm test`                         | —                     |
 
 > Type-checking `components`, `jukebox`, or `lyricova` requires the generated
 > `@lyricova/components/gql` to exist — run `npm run codegen -w @lyricova/components`

--- a/docs/jukebox-animation-timing.md
+++ b/docs/jukebox-animation-timing.md
@@ -1,0 +1,301 @@
+# Jukebox animation timing
+
+Jukebox lyrics animations are synchronized to media playback through a shared
+clock and a small set of animation controllers. This document describes that
+architecture and the rules for adding or changing a media-timed animation.
+
+## Goals
+
+The timing layer must keep an animation correct when:
+
+- the animated React node mounts after playback has started,
+- React reuses or remounts a node,
+- playback pauses, resumes, seeks, or changes rate,
+- the media element buffers,
+- a virtualized lyrics row enters or leaves the DOM,
+- React Strict Mode replays a ref lifecycle, and
+- browser scheduling differs between Chromium and Firefox.
+
+The central rule is:
+
+> `HTMLMediaElement.currentTime` is the authoritative playback position at
+> every synchronization point.
+
+Animation code must not independently reconstruct media time from
+`performance.now()`, wait for a WebVTT cue, or assume that a ref will be ready
+when an unrelated effect runs.
+
+## Architecture
+
+```text
+HTMLMediaElement
+  │
+  ├─ readPlaybackSnapshot()
+  │    └─ currentTime, duration, playbackRate, playing/paused
+  │
+  └─ useMediaClock()
+       ├─ media events + visibility restoration
+       ├─ one cancellable requestAnimationFrame loop while advancing
+       └─ consumers
+            ├─ usePlayerLyricsState() → current lyrics frame
+            ├─ usePlayerState() → transport changes
+            ├─ useWebAnimationController() → WAAPI Animation
+            └─ synchronizeGsapTimeline() → GSAP timeline
+```
+
+The relevant implementation files are:
+
+| Responsibility                                    | File                                                        |
+| ------------------------------------------------- | ----------------------------------------------------------- |
+| Media snapshots, clock subscription, frame lookup | `packages/jukebox/src/hooks/useMediaClock.ts`               |
+| Current lyrics frame selection                    | `packages/jukebox/src/hooks/usePlayerLyricsState.ts`        |
+| Playback and controller types                     | `packages/jukebox/src/hooks/types.ts`                       |
+| Web Animations API lifecycle                      | `packages/jukebox/src/hooks/useWebAnimationController.ts`   |
+| GSAP synchronization                              | `packages/jukebox/src/hooks/useTrackwiseTimelineControl.ts` |
+| General cancellable frame loop                    | `packages/jukebox/src/hooks/useAnimationFrame.ts`           |
+
+## Playback snapshots
+
+`readPlaybackSnapshot(player)` produces the complete state needed by an
+animation:
+
+```ts
+interface PlaybackSnapshot {
+  currentTime: number; // seconds
+  duration: number; // seconds; may be NaN before metadata
+  playbackRate: number;
+  state: "playing" | "paused";
+}
+```
+
+`state` describes whether an animation should advance, not merely the value of
+`player.paused`. A media element is treated as paused when it:
+
+- is explicitly paused,
+- has ended, or
+- has `readyState` lower than `HTMLMediaElement.HAVE_FUTURE_DATA`.
+
+The `waiting` and `stalled` events trigger a new snapshot. When `readyState`
+shows that playback cannot advance, the snapshot freezes the lyrics animation
+until enough future data is available again.
+
+Always read a fresh snapshot when synchronizing an animation:
+
+```ts
+const player = playerRef.current;
+if (player) {
+  animationRef.current?.synchronize(readPlaybackSnapshot(player));
+}
+```
+
+Do not calculate a substitute position from `PlayerState.startingAt`.
+
+## The media clock
+
+`useMediaClock(playerRef, onSnapshot)` subscribes to the events that can change
+transport state or invalidate timing:
+
+- metadata and duration changes,
+- play, playing, pause, and rate changes,
+- seeking and seek completion,
+- time updates,
+- buffering transitions, and
+- document visibility restoration.
+
+The hook emits immediately after it attaches. While media is advancing, it also
+maintains one `requestAnimationFrame` loop so short lyrics boundaries are not
+limited by the browser's relatively infrequent `timeupdate` events. The loop
+stops during pause, buffering, end-of-track, and cleanup.
+
+The callback is stored in a ref. Updating the callback therefore does not tear
+down the media listeners or create another frame loop.
+
+Use `{ animationFrames: false }` when a consumer only needs transport changes,
+as `usePlayerState` does:
+
+```ts
+useMediaClock(playerRef, synchronizeTransport, {
+  animationFrames: false,
+});
+```
+
+## Selecting the current lyrics frame
+
+`usePlayerLyricsState` no longer creates an HTML track or relies on `VTTCue`
+`enter` events. It:
+
+1. filters and orders finite keyframe start times,
+2. uses `findActiveKeyframeIndex` to find the latest start at or before
+   `currentTime`,
+3. updates React state only when the selected frame changes, and
+4. explicitly resynchronizes when the keyframe schedule changes while playback
+   is paused.
+
+The binary search returns `-1` before the first frame. Duplicate start times
+select the last keyframe at that time.
+
+Clock callbacks may run every rendered frame, but React components do not
+rerender every frame: `currentFrameId` is published only at a lyrics boundary.
+
+## Web Animations API
+
+Use `useWebAnimationController` for animations created with
+`element.animate()`.
+
+```tsx
+const TimedSpan = forwardRef<PlaybackAnimationController, Props>(
+  function TimedSpan({ duration, children }, ref) {
+    const createAnimation = useCallback(
+      (element: HTMLSpanElement) =>
+        element.animate([{ opacity: 0.5 }, { opacity: 1 }], {
+          duration: duration * 1000,
+          fill: "both",
+        }),
+      [duration],
+    );
+
+    const elementRef = useWebAnimationController(ref, createAnimation);
+
+    return (
+      <span ref={elementRef} style={{ opacity: 1 }}>
+        {children}
+      </span>
+    );
+  },
+);
+```
+
+The controller:
+
+- creates the animation when the callback ref attaches,
+- pauses it before initial synchronization,
+- remembers the latest snapshot even if no element is mounted,
+- reapplies that snapshot after `animation.ready` resolves,
+- sets both `currentTime` and `playbackRate`,
+- keeps completed, fill-mode animations paused at their end state, and
+- cancels the animation when the ref detaches or its factory changes.
+
+The factory should be wrapped in `useCallback`. Changing one of its
+dependencies deliberately detaches the old callback ref, cancels the old
+animation, and creates a new animation on the same DOM node.
+
+Base presentation belongs in React's `style` or class props. Do not mutate a DOM
+style and later use that style as an "animation initialized" flag.
+
+## GSAP timelines
+
+Create every media-controlled GSAP timeline paused and after its target nodes
+have committed:
+
+```tsx
+const [timeline, setTimeline] = useState<gsap.core.Timeline | null>(null);
+
+useLayoutEffect(() => {
+  const target = targetRef.current;
+  if (!target) return;
+
+  const nextTimeline = gsap
+    .timeline({ paused: true })
+    .fromTo(target, { x: 0 }, { x: 100, duration: 10, ease: "none" });
+
+  setTimeline(nextTimeline);
+  return () => nextTimeline.kill();
+}, [timingInputs]);
+
+useTrackwiseTimelineControl(playerRef, playerState, timeline);
+```
+
+`useTrackwiseTimelineControl` reads a fresh media snapshot whenever the
+transport or timeline changes. `synchronizeGsapTimeline`:
+
+- seeks the timeline to `snapshot.currentTime`,
+- applies `timeline.timeScale(snapshot.playbackRate)`, and
+- plays or pauses according to the snapshot.
+
+For a timeline whose zero point is a lyrics line rather than the track, pass
+the line start as the offset:
+
+```ts
+synchronizeGsapTimeline(timeline, snapshot, lineStart);
+```
+
+Do not create timelines, schedule animation frames, or read DOM refs inside
+`useMemo`. `useMemo` runs during render and may be replayed or discarded.
+
+## Nested and virtualized animation refs
+
+Lyrics renderers expose `PlaybackAnimationController`:
+
+```ts
+interface PlaybackAnimationController {
+  synchronize(snapshot: PlaybackSnapshot): void;
+}
+```
+
+A line renderer may aggregate several timed spans. It should translate the
+track snapshot into line-relative time once, then forward it to every child.
+Rows outside their active range receive a paused snapshot so completed/future
+effects retain the correct visual state.
+
+When a controller ref attaches, synchronize it immediately from the media
+element. Do not wait for the next play, pause, or `timeupdate` event. This is
+required for focused lyrics and virtualized rows that mount in the middle of a
+line.
+
+## Other animation-frame consumers
+
+Use `useAnimationFrame(callback, active)` for editor progress loops that do not
+delegate continuous advancement to WAAPI or GSAP.
+
+The hook schedules one reconciliation frame even while inactive, continues
+only while `active` is true, and cancels its outstanding frame on dependency
+change or unmount. The callback is kept in a ref, so a render does not start a
+second loop.
+
+Do not recursively call `requestAnimationFrame` from a component callback and
+also start that callback from an effect; that pattern can create overlapping
+loops.
+
+## Adding a media-timed animation
+
+1. Decide whether WAAPI, GSAP, or a callback-driven frame loop owns continuous
+   advancement.
+2. Create the animation only after its DOM target exists.
+3. Start WAAPI/GSAP objects paused.
+4. Expose or consume `PlaybackAnimationController` rather than separate
+   optional `resume`/`pause` methods.
+5. Synchronize immediately when either the player or animation becomes ready.
+6. Set playback rate as part of every synchronization.
+7. Cancel or kill the animation and any scheduled frame during cleanup.
+8. Recreate the animation when its timing, keyframes, content, or measured
+   layout changes.
+9. Keep React state updates at meaningful boundaries rather than publishing
+   every clock tick.
+
+## Testing
+
+Unit tests use Vitest/jsdom:
+
+```bash
+npm test -w @lyricova/jukebox
+```
+
+Browser behavior is covered with Playwright in real Chromium and Firefox:
+
+```bash
+npx playwright install chromium firefox
+npm run test:browser -w @lyricova/jukebox
+```
+
+The browser fixture is isolated from the API server:
+
+- configuration: `packages/jukebox/playwright.config.ts`
+- fixture: `packages/jukebox/tests/browser/fixture/`
+- specification:
+  `packages/jukebox/tests/browser/specs/animation-lifecycle.spec.ts`
+
+The suite covers mid-track mounting, seeks, playback-rate changes, play/pause,
+same-node animation replacement, Strict Mode ref replay, GSAP progress, WAAPI
+progress, and uncaught browser errors. Add a regression there when behavior
+depends on the real animation implementation or differs between browser
+engines.

--- a/package-lock.json
+++ b/package-lock.json
@@ -6104,6 +6104,22 @@
         "url": "^0.11.0"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@polka/url": {
       "version": "1.0.0-next.28",
       "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.28.tgz",
@@ -18870,6 +18886,52 @@
         "node": ">= 0.6.x"
       }
     },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/plimit-lit": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/plimit-lit/-/plimit-lit-1.6.1.tgz",
@@ -24436,6 +24498,7 @@
       },
       "devDependencies": {
         "@next/eslint-plugin-next": "^16.2.10",
+        "@playwright/test": "^1.61.1",
         "@types/lodash": "^4.14.149",
         "@types/node": "^24.13.2",
         "@types/react": "^19.1.2",
@@ -24444,7 +24507,8 @@
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-hooks": "^5.2.0",
-        "typescript": "^6.0.3"
+        "typescript": "^6.0.3",
+        "vite": "^7.3.6"
       },
       "peerDependencies": {
         "react": "^19.1.0",
@@ -28102,6 +28166,7 @@
         "@pixi/filter-bulge-pinch": "^5.1.1",
         "@pixi/filter-color-matrix": "^7.4.3",
         "@pixi/sprite": "^7.4.3",
+        "@playwright/test": "^1.61.1",
         "@posthog/nextjs-config": "^1.9.68",
         "@react-spring/web": "^9.7.3",
         "@reduxjs/toolkit": "^1.9.2",
@@ -28147,6 +28212,7 @@
         "smartypants": "^0.2.2",
         "sonner": "^2.0.3",
         "typescript": "^6.0.3",
+        "vite": "^7.3.6",
         "zod": "^4.4.3",
         "zustand": "^5.0.3"
       },
@@ -29039,6 +29105,15 @@
         "earcut": "^2.2.4",
         "eventemitter3": "^4.0.0",
         "url": "^0.11.0"
+      }
+    },
+    "@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "devOptional": true,
+      "requires": {
+        "playwright": "1.61.1"
       }
     },
     "@polka/url": {
@@ -36972,6 +37047,30 @@
           }
         }
       }
+    },
+    "playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "devOptional": true,
+      "requires": {
+        "fsevents": "2.3.2",
+        "playwright-core": "1.61.1"
+      },
+      "dependencies": {
+        "fsevents": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+          "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+          "optional": true
+        }
+      }
+    },
+    "playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "devOptional": true
     },
     "plimit-lit": {
       "version": "1.6.1",

--- a/packages/jukebox/.gitignore
+++ b/packages/jukebox/.gitignore
@@ -4,3 +4,5 @@ node_modules/
 build/
 tmp/
 temp/
+playwright-report/
+test-results/

--- a/packages/jukebox/next-env.d.ts
+++ b/packages/jukebox/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/packages/jukebox/package.json
+++ b/packages/jukebox/package.json
@@ -9,7 +9,8 @@
     "typecheck:native": "tsgo --noEmit",
     "start": "next start",
     "lint": "eslint .",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:browser": "playwright test"
   },
   "repository": {
     "type": "git",
@@ -86,6 +87,7 @@
   },
   "devDependencies": {
     "@next/eslint-plugin-next": "^16.2.10",
+    "@playwright/test": "^1.61.1",
     "@types/lodash": "^4.14.149",
     "@types/node": "^24.13.2",
     "@types/react": "^19.1.2",
@@ -94,7 +96,8 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^5.2.0",
-    "typescript": "^6.0.3"
+    "typescript": "^6.0.3",
+    "vite": "^7.3.6"
   },
   "peerDependencies": {
     "react": "^19.1.0",

--- a/packages/jukebox/playwright.config.ts
+++ b/packages/jukebox/playwright.config.ts
@@ -1,0 +1,29 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests/browser/specs",
+  fullyParallel: true,
+  forbidOnly: Boolean(process.env.CI),
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? "github" : "line",
+  use: {
+    baseURL: "http://127.0.0.1:4173",
+    trace: "on-first-retry",
+  },
+  webServer: {
+    command: "vite --config tests/browser/vite.config.ts --host 127.0.0.1",
+    cwd: __dirname,
+    port: 4173,
+    reuseExistingServer: !process.env.CI,
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+    {
+      name: "firefox",
+      use: { ...devices["Desktop Firefox"] },
+    },
+  ],
+});

--- a/packages/jukebox/src/components/dashboard/musicFilesDetails/LyricsPreview.tsx
+++ b/packages/jukebox/src/components/dashboard/musicFilesDetails/LyricsPreview.tsx
@@ -12,10 +12,15 @@ import { measureTextWidths } from "../../../frontendUtils/measure";
 import { safeDuration } from "../../../frontendUtils/safeDuration";
 import { useActiveLyrcsRanges } from "../../../hooks/useActiveLyricsRanges";
 import { cn } from "@lyricova/components/utils";
+import type {
+  PlaybackAnimationController,
+  PlaybackSnapshot,
+} from "../../../hooks/types";
+import { useWebAnimationController } from "../../../hooks/useWebAnimationController";
+import { readPlaybackSnapshot } from "../../../hooks/useMediaClock";
 
 interface LyricsRowRefs {
-  resume(time: number): void;
-  pause(time: number): void;
+  synchronize(snapshot: PlaybackSnapshot): void;
   scrollToCenter(): void;
 }
 
@@ -31,22 +36,45 @@ const LyricsRow = forwardRef<LyricsRowRefs, LyricsRowProps>(function LyricsRow(
   ref,
 ) {
   const boxRef = useRef<HTMLDivElement>(null);
-  const webAnimationRef = useRef<Animation>(null);
+  const animationControllerRef = useRef<PlaybackAnimationController>(null);
+  const createAnimation = useCallback(
+    (target: HTMLDivElement) => {
+      const tags = line.attachments?.timeTag?.tags ?? [];
+      const lengths = measureTextWidths(target);
+      const length = lengths.at(-1) ?? 0;
+      const percentages = lengths.map((value) =>
+        length > 0 ? (value / length) * 100 : 0,
+      );
+      const duration = safeDuration(start, end, 1, { line });
+      const keyframes = tags
+        .map((tag) => ({
+          offset: Math.min(1, Math.max(tag.timeTag / duration, 0)),
+          backgroundSize: `${percentages[tag.index - 1] ?? 0}% 100%`,
+        }))
+        .toSorted((left, right) => left.offset - right.offset);
+
+      return target.animate(keyframes, {
+        duration: Math.max(0.1, duration * 1000),
+        fill: "forwards",
+        id: `background-size-${line.position}`,
+      });
+    },
+    [end, line, start],
+  );
+  const animationTargetRef = useWebAnimationController(
+    animationControllerRef,
+    createAnimation,
+  );
 
   useImperativeHandle(ref, () => ({
-    resume(time: number) {
-      if (webAnimationRef.current && start <= time && time <= end) {
-        webAnimationRef.current.currentTime = (time - start) * 1000;
-        webAnimationRef.current.play();
-      }
-    },
-    pause(time: number) {
-      if (webAnimationRef.current) {
-        if (start <= time && time <= end) {
-          webAnimationRef.current.currentTime = (time - start) * 1000;
-        }
-        webAnimationRef.current.pause();
-      }
+    synchronize(snapshot) {
+      const isInRange =
+        start <= snapshot.currentTime && snapshot.currentTime <= end;
+      animationControllerRef.current?.synchronize({
+        ...snapshot,
+        currentTime: snapshot.currentTime - start,
+        state: isInRange ? snapshot.state : "paused",
+      });
     },
     scrollToCenter() {
       requestAnimationFrame(() =>
@@ -68,32 +96,13 @@ const LyricsRow = forwardRef<LyricsRowRefs, LyricsRowProps>(function LyricsRow(
         line.attachments.role % 3 === 2 && "text-center",
         line.attachments.minor && "text-base opacity-75",
       )}
-      ref={(elm: HTMLDivElement) => {
-        if (!elm || boxRef.current === elm) return;
-        boxRef.current = elm;
-        const tags = line?.attachments?.timeTag?.tags;
-        if (elm && tags?.length) {
-          const target = elm.querySelector(".furigana") as HTMLDivElement;
-          target.style.backgroundSize = "0% 100%";
-          const lengths = measureTextWidths(target);
-          const length = lengths.at(-1) ?? 0;
-          const percentages = lengths.map((v) => (v / length) * 100);
-          const duration = safeDuration(start, end, 1, { line });
-          const keyframes = tags.map((v) => ({
-            offset: Math.min(1, Math.max(v.timeTag / duration, 0)),
-            backgroundSize: `${percentages[v.index - 1] ?? 0}% 100%`,
-          }));
-          keyframes.sort((a, b) => a.offset - b.offset);
-          webAnimationRef.current = target.animate(keyframes, {
-            duration: Math.max(0.1, duration * 1000),
-            fill: "forwards",
-            id: `background-size-${line.position}`,
-          });
-          webAnimationRef.current.pause();
-        }
-      }}
+      ref={boxRef}
     >
-      <div className="furigana group-data-[active=true]/lyrics-row:inline group-data-[active=true]/lyrics-row:bg-linear-to-r group-data-[active=true]/lyrics-row:from-info-foreground/30 group-data-[active=true]/lyrics-row:to-info-foreground/30 group-data-[active=true]/lyrics-row:bg-blend-difference group-data-[active=true]/lyrics-row:bg-no-repeat group-data-[active=true]/lyrics-row:bg-size-[0%_100%]">
+      <div
+        ref={animationTargetRef}
+        className="furigana group-data-[active=true]/lyrics-row:inline group-data-[active=true]/lyrics-row:bg-linear-to-r group-data-[active=true]/lyrics-row:from-info-foreground/30 group-data-[active=true]/lyrics-row:to-info-foreground/30 group-data-[active=true]/lyrics-row:bg-blend-difference group-data-[active=true]/lyrics-row:bg-no-repeat"
+        style={{ backgroundSize: "0% 100%" }}
+      >
         <FuriganaLyricsLine lyricsKitLine={line} />
       </div>
       {Object.entries(line.attachments.translations).map(([lang, content]) => (
@@ -139,20 +148,15 @@ export default function LyricsPreview({ lyrics, fileId, className }: Props) {
   const currentFrameRef = useRef(currentFrame);
   currentFrameRef.current = currentFrame;
 
-  const rowRefs = useRef<LyricsRowRefs[]>([]);
+  const rowRefs = useRef<(LyricsRowRefs | null)[]>([]);
 
   // Controls the progress of timeline
   useEffect(() => {
+    const player = playerRef.current;
+    if (!player) return;
+    const snapshot = readPlaybackSnapshot(player);
+    rowRefs.current.forEach((rowRef) => rowRef?.synchronize(snapshot));
     const activeSegments = currentFrameRef.current?.data.activeSegments ?? [];
-    activeSegments.forEach((idx) => {
-      if (playerState.state === "playing") {
-        const now = performance.now();
-        const progress = (now - playerState.startingAt) / 1000;
-        rowRefs.current[idx]?.resume(progress);
-      } else {
-        rowRefs.current[idx]?.pause(playerState.progress);
-      }
-    });
     if (activeSegments.length) {
       const lastActiveSegment = activeSegments.at(-1);
       if (lastActiveSegment !== undefined) {
@@ -162,15 +166,24 @@ export default function LyricsPreview({ lyrics, fileId, className }: Props) {
   }, [playerState, currentFrame]);
 
   // Row ref cache to prevent row rerender.
-  const rowRefUpdaterCache = useRef<((r: LyricsRowRefs) => void)[]>([]);
-  const rowRefUpdater = useCallback((idx: number) => {
-    if (!rowRefUpdaterCache.current[idx]) {
-      rowRefUpdaterCache.current[idx] = (r: LyricsRowRefs) => {
-        rowRefs.current[idx] = r;
-      };
-    }
-    return rowRefUpdaterCache.current[idx];
-  }, []);
+  const rowRefUpdaterCache = useRef<((rowRef: LyricsRowRefs | null) => void)[]>(
+    [],
+  );
+  const rowRefUpdater = useCallback(
+    (idx: number) => {
+      if (!rowRefUpdaterCache.current[idx]) {
+        rowRefUpdaterCache.current[idx] = (rowRef: LyricsRowRefs | null) => {
+          rowRefs.current[idx] = rowRef;
+          const player = playerRef.current;
+          if (rowRef && player) {
+            rowRef.synchronize(readPlaybackSnapshot(player));
+          }
+        };
+      }
+      return rowRefUpdaterCache.current[idx];
+    },
+    [playerRef],
+  );
 
   return (
     <div className={cn("h-[calc(100vh-10rem)] flex flex-col", className)}>

--- a/packages/jukebox/src/components/dashboard/musicFilesDetails/LyricsPreview.tsx
+++ b/packages/jukebox/src/components/dashboard/musicFilesDetails/LyricsPreview.tsx
@@ -20,6 +20,7 @@ import { useWebAnimationController } from "../../../hooks/useWebAnimationControl
 import { readPlaybackSnapshot } from "../../../hooks/useMediaClock";
 
 interface LyricsRowRefs {
+  /** Synchronize this row's line-local animation with media playback. */
   synchronize(snapshot: PlaybackSnapshot): void;
   scrollToCenter(): void;
 }
@@ -31,6 +32,9 @@ type LyricsRowProps = {
   end?: number;
 };
 
+/**
+ * Render a preview row with a media-controlled per-character fill animation.
+ */
 const LyricsRow = forwardRef<LyricsRowRefs, LyricsRowProps>(function LyricsRow(
   { line, isActive, start = 0, end = 1e100 },
   ref,
@@ -137,6 +141,12 @@ interface Props {
   className?: string;
 }
 
+/**
+ * Render an audio-backed lyrics preview and synchronize every mounted row.
+ *
+ * Newly mounted rows receive the current snapshot immediately, while active
+ * rows are centered as the playback frame changes.
+ */
 export default function LyricsPreview({ lyrics, fileId, className }: Props) {
   const playerRef = useRef<HTMLAudioElement>(null!);
   const containerRef = useRef<HTMLDivElement>(null);

--- a/packages/jukebox/src/components/dashboard/musicFilesDetails/lyrics/TaggingLyrics.tsx
+++ b/packages/jukebox/src/components/dashboard/musicFilesDetails/lyrics/TaggingLyrics.tsx
@@ -7,6 +7,7 @@
 import type { PlayerState } from "../../../../hooks/types";
 import { useNamedState } from "../../../../hooks/useNamedState";
 import { usePlayerState } from "../../../../hooks/usePlayerState";
+import { useAnimationFrame } from "../../../../hooks/useAnimationFrame";
 import type { MouseEvent, MouseEventHandler } from "react";
 import { useCallback, useEffect, useRef, useMemo, memo } from "react";
 import { Pencil } from "lucide-react";
@@ -185,55 +186,39 @@ export default function TaggingLyrics({ fileId }: Props) {
   }, [reset]);
 
   // Update time tags
-  const onFrame = useCallback(
-    (timestamp: number) => {
-      const playerState = playerStateRef.current;
-      const currentLine = useLyricsStore.getState().tagging.currentLine;
-      const lines = useLyricsStore.getState().lyrics?.lines ?? [];
+  const onFrame = useCallback(() => {
+    const currentLine = useLyricsStore.getState().tagging.currentLine;
+    const lines = useLyricsStore.getState().lyrics?.lines ?? [];
+    const time = playerRef.current?.currentTime ?? 0;
 
-      let time: number;
-      if (playerState.state === "paused") {
-        time = playerState.progress;
-      } else {
-        time = ((timestamp - playerState.startingAt) / 1000) * playerState.rate;
-      }
-
-      if (
-        (time < currentLine.start || time > currentLine.end) &&
-        lines.length > 0
-      ) {
-        const record = lines.reduce(
-          (p, c, i) => {
-            if (c.position) {
-              if (c.position < p.end && c.position > time) {
-                p.end = c.position;
-              }
-              if (c.position > p.start && c.position <= time) {
-                p.start = c.position;
-                p.index = i;
-              }
+    if (
+      (time < currentLine.start || time > currentLine.end) &&
+      lines.length > 0
+    ) {
+      const record = lines.reduce(
+        (p, c, i) => {
+          if (c.position) {
+            if (c.position < p.end && c.position > time) {
+              p.end = c.position;
             }
-            return p;
-          },
-          {
-            index: -Infinity,
-            start: -Infinity,
-            end: Infinity,
-          },
-        );
-        setCurrentLine(record);
-      }
+            if (c.position > p.start && c.position <= time) {
+              p.start = c.position;
+              p.index = i;
+            }
+          }
+          return p;
+        },
+        {
+          index: -Infinity,
+          start: -Infinity,
+          end: Infinity,
+        },
+      );
+      setCurrentLine(record);
+    }
+  }, [setCurrentLine]);
 
-      if (playerState.state === "playing") {
-        requestAnimationFrame(onFrame);
-      }
-    },
-    [setCurrentLine],
-  );
-
-  useEffect(() => {
-    requestAnimationFrame(onFrame);
-  }, [onFrame, playerState]);
+  useAnimationFrame(onFrame, playerState.state === "playing");
 
   const handleExtrapolateModeToggle = useCallback(
     (checked: boolean) => {
@@ -283,7 +268,7 @@ export default function TaggingLyrics({ fileId }: Props) {
       if (!line) return;
       playerRef.current.currentTime = line.position;
       if (playerStateRef.current.state !== "playing") {
-        requestAnimationFrame(onFrame);
+        onFrame();
       }
     },
     [moveCursor, onFrame],
@@ -354,12 +339,7 @@ export default function TaggingLyrics({ fileId }: Props) {
       if (code === "Space" || key === " " || key === "Spacebar") {
         ev.preventDefault();
         if (!playerRef.current || !playerStateRef.current) return;
-        const perfNow = performance.now();
-        const time =
-          playerStateRef.current.state === "playing"
-            ? ((perfNow - playerStateRef.current.startingAt) / 1000) *
-              playerStateRef.current.rate
-            : playerStateRef.current.progress;
+        const time = playerRef.current.currentTime;
 
         if (!isInExtrapolateMode) {
           setTimestampAtCursor(time);

--- a/packages/jukebox/src/components/dashboard/musicFilesDetails/lyrics/TaggingLyrics.tsx
+++ b/packages/jukebox/src/components/dashboard/musicFilesDetails/lyrics/TaggingLyrics.tsx
@@ -142,6 +142,9 @@ function ExtrapolateModeToggle({
 }
 const ExtrapolateModeToggleMemo = memo(ExtrapolateModeToggle);
 
+/**
+ * Render the native-audio lyrics tagging editor with media-clock highlighting.
+ */
 export default function TaggingLyrics({ fileId }: Props) {
   const [playbackRate, setPlaybackRate] = useNamedState(1, "playbackRate");
 

--- a/packages/jukebox/src/components/dashboard/musicFilesDetails/lyrics/TaggingLyrics.tsx
+++ b/packages/jukebox/src/components/dashboard/musicFilesDetails/lyrics/TaggingLyrics.tsx
@@ -218,7 +218,11 @@ export default function TaggingLyrics({ fileId }: Props) {
     }
   }, [setCurrentLine]);
 
-  useAnimationFrame(onFrame, playerState.state === "playing");
+  useAnimationFrame(
+    onFrame,
+    playerState.state === "playing",
+    playerState.state === "paused" ? playerState.progress : undefined,
+  );
 
   const handleExtrapolateModeToggle = useCallback(
     (checked: boolean) => {

--- a/packages/jukebox/src/components/dashboard/musicFilesDetails/lyrics/WebAudioTaggingLyrics.tsx
+++ b/packages/jukebox/src/components/dashboard/musicFilesDetails/lyrics/WebAudioTaggingLyrics.tsx
@@ -224,7 +224,11 @@ export default function WebAudioTaggingLyrics({ fileId }: Props) {
     }
   }, [getProgress, setCurrentLine, setPlaybackProgress]);
 
-  useAnimationFrame(onFrame, playerStatus.state === "playing");
+  useAnimationFrame(
+    onFrame,
+    playerStatus.state === "playing",
+    playerStatus.state === "paused" ? playerStatus.progress : undefined,
+  );
 
   const handleExtrapolateModeToggle = useCallback(
     (checked: boolean) => {

--- a/packages/jukebox/src/components/dashboard/musicFilesDetails/lyrics/WebAudioTaggingLyrics.tsx
+++ b/packages/jukebox/src/components/dashboard/musicFilesDetails/lyrics/WebAudioTaggingLyrics.tsx
@@ -9,6 +9,7 @@
  */
 import { useNamedState } from "../../../../hooks/useNamedState";
 import { useWebAudio } from "../../../../hooks/useWebAudio";
+import { useAnimationFrame } from "../../../../hooks/useAnimationFrame";
 import type { WebAudioPlayerState } from "../../../../hooks/types";
 import type { MouseEvent, MouseEventHandler } from "react";
 import { useCallback, useEffect, useRef, useMemo, memo } from "react";
@@ -221,15 +222,9 @@ export default function WebAudioTaggingLyrics({ fileId }: Props) {
       );
       setCurrentLine(record);
     }
-
-    if (playerStatus.state === "playing") {
-      requestAnimationFrame(onFrame);
-    }
   }, [getProgress, setCurrentLine, setPlaybackProgress]);
 
-  useEffect(() => {
-    requestAnimationFrame(onFrame);
-  }, [onFrame, playerStatus]);
+  useAnimationFrame(onFrame, playerStatus.state === "playing");
 
   const handleExtrapolateModeToggle = useCallback(
     (checked: boolean) => {
@@ -279,7 +274,7 @@ export default function WebAudioTaggingLyrics({ fileId }: Props) {
       if (!line) return;
       seek(line.position);
       if (playerStatusRef.current.state !== "playing") {
-        requestAnimationFrame(onFrame);
+        onFrame();
       }
     },
     [audioBuffer, moveCursor, onFrame, seek],

--- a/packages/jukebox/src/components/dashboard/musicFilesDetails/lyrics/WebAudioTaggingLyrics.tsx
+++ b/packages/jukebox/src/components/dashboard/musicFilesDetails/lyrics/WebAudioTaggingLyrics.tsx
@@ -143,6 +143,9 @@ interface Props {
   fileId: number;
 }
 
+/**
+ * Render the Web Audio lyrics tagging editor with frame-synchronized progress.
+ */
 export default function WebAudioTaggingLyrics({ fileId }: Props) {
   const {
     linesLength,

--- a/packages/jukebox/src/components/dashboard/musicFilesDetails/lyrics/inlineTagging/InlineTagging.tsx
+++ b/packages/jukebox/src/components/dashboard/musicFilesDetails/lyrics/inlineTagging/InlineTagging.tsx
@@ -316,7 +316,11 @@ export default function InlineTagging({ fileId }: Props) {
     }
   }, [getProgress, setPlaybackProgress]);
 
-  useAnimationFrame(onFrame, playerStatus.state === "playing");
+  useAnimationFrame(
+    onFrame,
+    playerStatus.state === "playing",
+    playerStatus.state === "paused" ? playerStatus.progress : undefined,
+  );
 
   useEffect(() => {
     const snapshot = {

--- a/packages/jukebox/src/components/dashboard/musicFilesDetails/lyrics/inlineTagging/InlineTagging.tsx
+++ b/packages/jukebox/src/components/dashboard/musicFilesDetails/lyrics/inlineTagging/InlineTagging.tsx
@@ -31,6 +31,8 @@ import { Toggle } from "@lyricova/components/components/ui/toggle";
 import { CheckSquare } from "lucide-react";
 import { YohaneAlign } from "./YohaneAlign";
 import { CustomAlign } from "./CustomAlign";
+import { useAnimationFrame } from "../../../../../hooks/useAnimationFrame";
+import { synchronizeGsapTimeline } from "../../../../../hooks/useTrackwiseTimelineControl";
 
 function Instructions() {
   return (
@@ -257,7 +259,6 @@ export default function InlineTagging({ fileId }: Props) {
   }, [getProgress, section, seek]);
 
   const timelinesRef = useRef<(gsap.core.Timeline | undefined)[]>([]);
-  const isMounted = useRef(true);
 
   // Update time tags
   const onFrame = useCallback(() => {
@@ -313,28 +314,27 @@ export default function InlineTagging({ fileId }: Props) {
       );
       setCurrentLine(record);
     }
-
-    if (playerStatus.state === "playing" && isMounted.current) {
-      requestAnimationFrame(onFrame);
-    }
   }, [getProgress, setPlaybackProgress]);
 
+  useAnimationFrame(onFrame, playerStatus.state === "playing");
+
   useEffect(() => {
-    isMounted.current = true;
-    requestAnimationFrame(onFrame);
-    if (timelinesRef.current) {
-      const progress = getProgress();
-      if (playerStatus.state === "playing") {
-        timelinesRef.current?.map((t) => t?.play(progress));
-      } else if (playerStatus.state === "paused") {
-        timelinesRef.current?.map((t) => t?.pause(progress));
-      }
-    }
-    return () => {
-      isMounted.current = false;
-      timelinesRef.current?.map((t) => t?.kill());
+    const snapshot = {
+      currentTime: getProgress(),
+      duration: audioBuffer?.duration ?? Number.NaN,
+      playbackRate: playerStatus.rate,
+      state: playerStatus.state,
     };
-  }, [getProgress, onFrame, playerStatus]);
+    timelinesRef.current.forEach((timeline) => {
+      if (timeline) synchronizeGsapTimeline(timeline, snapshot);
+    });
+  }, [audioBuffer?.duration, getProgress, playerStatus]);
+
+  useEffect(() => {
+    return () => {
+      timelinesRef.current.forEach((timeline) => timeline?.kill());
+    };
+  }, []);
 
   // Register playback control listener
   useEffect(() => {

--- a/packages/jukebox/src/components/dashboard/musicFilesDetails/lyrics/inlineTagging/InlineTagging.tsx
+++ b/packages/jukebox/src/components/dashboard/musicFilesDetails/lyrics/inlineTagging/InlineTagging.tsx
@@ -65,6 +65,12 @@ interface Props {
   fileId: number;
 }
 
+/**
+ * Render inline lyrics tagging and synchronize its per-line GSAP timelines.
+ *
+ * Playback changes update every mounted timeline from one Web Audio snapshot,
+ * and all timelines are killed when the editor unmounts.
+ */
 export default function InlineTagging({ fileId }: Props) {
   const { playerStatus, play, pause, seek, setRate, getProgress, audioBuffer } =
     useWebAudio(`/api/files/${fileId}/file`);

--- a/packages/jukebox/src/components/dashboard/musicFilesDetails/lyrics/inlineTagging/InlineTaggingLine.tsx
+++ b/packages/jukebox/src/components/dashboard/musicFilesDetails/lyrics/inlineTagging/InlineTaggingLine.tsx
@@ -63,6 +63,12 @@ interface InlineTaggingLineProps {
   section: "mark" | "tag";
 }
 
+/**
+ * Render one inline-tagging row and own its line-local GSAP fill timeline.
+ *
+ * The timeline is created only for the active row, initialized from Web Audio
+ * state, and killed when the row leaves the active range or unmounts.
+ */
 function InlineTaggingLine({
   index,
   timelinesRef,

--- a/packages/jukebox/src/components/dashboard/musicFilesDetails/lyrics/inlineTagging/InlineTaggingLine.tsx
+++ b/packages/jukebox/src/components/dashboard/musicFilesDetails/lyrics/inlineTagging/InlineTaggingLine.tsx
@@ -4,6 +4,7 @@ import { memo, useCallback, useEffect, useRef, useState } from "react";
 import { measureTextWidths } from "../../../../../frontendUtils/measure";
 import type { WebAudioPlayerState } from "../../../../../hooks/types";
 import gsap from "gsap";
+import { synchronizeGsapTimeline } from "../../../../../hooks/useTrackwiseTimelineControl";
 import {
   Tooltip,
   TooltipContent,
@@ -158,7 +159,7 @@ function InlineTaggingLine({
         timelinesRef.current = [];
         return;
       }
-      const tl = gsap.timeline();
+      const tl = gsap.timeline({ paused: true });
 
       let start = -1;
       startingTags.forEach((x, idx) => {
@@ -189,14 +190,20 @@ function InlineTaggingLine({
           start = x;
         }
       });
-      tl.timeScale(playerStatusRef.current.rate);
       const progress = getProgress();
-      if (playerStatusRef.current.state === "playing") {
-        tl.play(progress);
-      } else {
-        tl.pause(progress);
-      }
+      synchronizeGsapTimeline(tl, {
+        currentTime: progress,
+        duration: Number.NaN,
+        playbackRate: playerStatusRef.current.rate,
+        state: playerStatusRef.current.state,
+      });
       timelinesRef.current[index] = tl;
+      return () => {
+        if (timelinesRef.current[index] === tl) {
+          timelinesRef.current[index] = undefined;
+        }
+        tl.kill();
+      };
     } else if (relativeProgress === 1) {
       centerRow.style.backgroundSize = "0px 100%";
       if (timelinesRef.current?.[index]) {
@@ -218,8 +225,6 @@ function InlineTaggingLine({
         timelinesRef.current[index] = undefined;
       }
     }
-    // return () => {timelinesRef.current[index] = undefined; };
-    // Explicitly only depends on relativeProgress to prevent excessive re-renders
   }, [
     relativeProgress,
     index,

--- a/packages/jukebox/src/components/public/lyrics/amll.tsx
+++ b/packages/jukebox/src/components/public/lyrics/amll.tsx
@@ -21,6 +21,12 @@ interface Props {
   transLangIdx?: number;
 }
 
+/**
+ * Adapt Lyricova lines to Apple Music-like lyric words and playback timing.
+ *
+ * Media-clock snapshots drive millisecond progress so seeks, stalls, rate
+ * changes, and paused updates remain synchronized with the external renderer.
+ */
 export function AMLLyrics({ lyrics, transLangIdx }: Props) {
   const { playerRef } = useAppContext();
   const playerState = usePlayerState(playerRef);

--- a/packages/jukebox/src/components/public/lyrics/amll.tsx
+++ b/packages/jukebox/src/components/public/lyrics/amll.tsx
@@ -1,5 +1,5 @@
 import type { LyricsKitLyrics } from "@lyricova/components/gql/schema";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import type {
   LyricLine as AAMLyricLine,
   LyricWord as AMLLyricWord,
@@ -7,6 +7,7 @@ import type {
 import { useAppContext } from "../AppContext";
 import { usePlayerState } from "../../../hooks/usePlayerState";
 import dynamic from "next/dynamic";
+import { useMediaClock } from "../../../hooks/useMediaClock";
 
 const LyricPlayer = dynamic(
   () => import("../compat/amllLyricsPlayer").then((m) => m.LyricPlayer),
@@ -90,31 +91,14 @@ export function AMLLyrics({ lyrics, transLangIdx }: Props) {
   }, [lang, lyrics.lines, playerRef]);
 
   const [playbackProgressMs, setPlaybackProgressMs] = useState(
-    Math.floor(playerRef.current.currentTime * 1000),
+    Math.floor((playerRef.current?.currentTime ?? 0) * 1000),
   );
-  const updatePlaybackProgressMs = useCallback(() => {
-    setPlaybackProgressMs(Math.floor(playerRef.current.currentTime * 1000));
-    if (playerRef.current?.paused !== true) {
-      requestAnimationFrame(updatePlaybackProgressMs);
-    }
-  }, [playerRef]);
-
-  useEffect(() => {
-    requestAnimationFrame(updatePlaybackProgressMs);
-  }, [playerState.state, updatePlaybackProgressMs]);
-
-  useEffect(() => {
-    function onTimeUpdate() {
-      requestAnimationFrame(updatePlaybackProgressMs);
-    }
-    const player = playerRef.current;
-    player.addEventListener("timeupdate", onTimeUpdate);
-    player.addEventListener("seeked", onTimeUpdate);
-    return () => {
-      player.removeEventListener("timeupdate", onTimeUpdate);
-      player.removeEventListener("seeked", onTimeUpdate);
-    };
-  }, [playerRef, updatePlaybackProgressMs]);
+  useMediaClock(playerRef, (snapshot) => {
+    const nextProgress = Math.floor(snapshot.currentTime * 1000);
+    setPlaybackProgressMs((progress) =>
+      progress === nextProgress ? progress : nextProgress,
+    );
+  });
 
   return (
     <div

--- a/packages/jukebox/src/components/public/lyrics/components/AnimationRef.type.tsx
+++ b/packages/jukebox/src/components/public/lyrics/components/AnimationRef.type.tsx
@@ -1,4 +1,3 @@
-export interface LyricsAnimationRef {
-  resume: (time?: number) => void;
-  pause: (time?: number) => void;
-}
+import type { PlaybackAnimationController } from "../../../../hooks/types";
+
+export type LyricsAnimationRef = PlaybackAnimationController;

--- a/packages/jukebox/src/components/public/lyrics/components/LyricsVirtualizer.tsx
+++ b/packages/jukebox/src/components/public/lyrics/components/LyricsVirtualizer.tsx
@@ -9,6 +9,7 @@ import { useAppContext } from "../../AppContext";
 import type { VirtualizerRowRenderProps } from "./useLyricsVirtualizer";
 import { useLyricsVirtualizer } from "./useLyricsVirtualizer";
 import type { LyricsAnimationRef } from "./AnimationRef.type";
+import { readPlaybackSnapshot } from "../../../../hooks/useMediaClock";
 
 export interface RowRendererProps<T> {
   row: T;
@@ -53,49 +54,30 @@ export function LyricsVirtualizer({
     rows,
     playerRef,
   );
-  const playerStateRef = useRef(playerState);
-  playerStateRef.current = playerState;
 
   useEffect(() => {
-    if (playerState.state === "playing") {
-      const currentTime =
-        (performance.now() - playerState.startingAt) / playerState.rate / 1000;
-      animationRefs.current.forEach((ref) => {
-        if (ref) {
-          ref.resume(currentTime);
-        }
-      });
-    } else {
-      animationRefs.current.forEach((ref) => {
-        if (ref) {
-          ref.pause(playerState.progress);
-        }
-      });
-    }
-  }, [playerState]);
+    const player = playerRef.current;
+    if (!player) return;
+    const snapshot = readPlaybackSnapshot(player);
+    animationRefs.current.forEach((animationRef) => {
+      animationRef?.synchronize(snapshot);
+    });
+  }, [currentFrame, playerRef, playerState]);
 
   const endRow = currentFrame?.data?.rangeEnd ?? 0;
   const startRow = currentFrame?.data?.rangeStart ?? 0;
-  const activeSegmentsRef = useRef<number[]>([]);
-  activeSegmentsRef.current = currentFrame?.data?.activeSegments ?? [];
+  const activeSegments = currentFrame?.data?.activeSegments;
   const animationRefs = useRef<(LyricsAnimationRef | null)[]>([]);
   const setRef = useCallback(
     (index: number) => (ref: LyricsAnimationRef | null) => {
       if (animationRefs.current[index] === ref) return;
       animationRefs.current[index] = ref;
-      if (ref) {
-        if (playerStateRef.current.state === "playing") {
-          const currentTime =
-            (performance.now() - playerStateRef.current.startingAt) /
-            playerStateRef.current.rate /
-            1000;
-          ref.resume(currentTime);
-        } else {
-          ref.pause(playerStateRef.current.progress);
-        }
+      const player = playerRef.current;
+      if (ref && player) {
+        ref.synchronize(readPlaybackSnapshot(player));
       }
     },
-    [],
+    [playerRef],
   );
 
   const virtualizerRowRender = useCallback(
@@ -115,7 +97,7 @@ export function LyricsVirtualizer({
         top,
         absoluteIndex,
         isActiveScroll,
-        isActive: activeSegmentsRef.current.includes(index),
+        isActive: activeSegments?.includes(index) ?? false,
         animationRef: setRef(index),
         onClick: () => {
           const segment = segments[index];
@@ -124,7 +106,7 @@ export function LyricsVirtualizer({
           }
         },
       }),
-    [playerRef, rowRenderer, rows, segments, setRef],
+    [activeSegments, playerRef, rowRenderer, rows, segments, setRef],
   );
 
   const { renderedRows, isActiveScroll } = useLyricsVirtualizer({

--- a/packages/jukebox/src/components/public/lyrics/components/LyricsVirtualizer.tsx
+++ b/packages/jukebox/src/components/public/lyrics/components/LyricsVirtualizer.tsx
@@ -38,6 +38,12 @@ export interface LyricsVirtualizerProps<
   containerProps?: React.ComponentProps<TELement>;
 }
 
+/**
+ * Virtualize lyric rows and keep their imperative animations on the media clock.
+ *
+ * Animation refs are synchronized both when playback changes and when a
+ * virtualized row mounts. Clicking a row seeks to its segment start.
+ */
 export function LyricsVirtualizer({
   children: rowRenderer,
   rows,

--- a/packages/jukebox/src/components/public/lyrics/components/RubyLineRenderer.tsx
+++ b/packages/jukebox/src/components/public/lyrics/components/RubyLineRenderer.tsx
@@ -136,6 +136,12 @@ interface LineRendererProps<TContainer extends ElementType = ElementType> {
   timedSpan: TimedSpanComponent;
 }
 
+/**
+ * Render timed text and ruby segments behind one line-local animation controller.
+ *
+ * Playback snapshots are rebased to the line start, and out-of-range lines are
+ * held paused so all child span animations share the same timing contract.
+ */
 const InnerLineRenderer = forwardRef<LyricsAnimationRef, LineRendererProps>(
   function InnerLineRenderer(
     {
@@ -156,6 +162,7 @@ const InnerLineRenderer = forwardRef<LyricsAnimationRef, LineRendererProps>(
     };
 
     useImperativeHandle(ref, () => ({
+      /** Forward a line-local playback snapshot to every animated span. */
       synchronize(snapshot: PlaybackSnapshot) {
         const isInRange =
           start <= snapshot.currentTime && snapshot.currentTime <= end;

--- a/packages/jukebox/src/components/public/lyrics/components/RubyLineRenderer.tsx
+++ b/packages/jukebox/src/components/public/lyrics/components/RubyLineRenderer.tsx
@@ -9,6 +9,7 @@ import { forwardRef, memo, useImperativeHandle, useRef } from "react";
 import type { LyricsAnimationRef } from "./AnimationRef.type";
 import type { LyricsKitLyricsLine } from "@lyricova/components/gql/schema";
 import FuriganaLyricsLine from "../../../FuriganaLyricsLine";
+import type { PlaybackSnapshot } from "../../../../hooks/types";
 
 function lineToTimeSegments(
   line: LyricsKitLyricsLine,
@@ -155,39 +156,17 @@ const InnerLineRenderer = forwardRef<LyricsAnimationRef, LineRendererProps>(
     };
 
     useImperativeHandle(ref, () => ({
-      resume(time?: number) {
-        if (!Object.keys(animationRefs.current).length) {
-          console.log("no refs found in array");
-          return;
-        }
-
-        const currentTime = time ?? 0;
-        if (start <= currentTime && currentTime <= end) {
-          Object.values(animationRefs.current).forEach((ref) =>
-            ref
-              ? ref?.resume(currentTime - start)
-              : console.log("ref is not found", ref),
-          );
-        } else {
-          Object.values(animationRefs.current).forEach((ref) =>
-            ref
-              ? ref?.pause(currentTime - start)
-              : console.log("ref is not found", ref),
-          );
-        }
-      },
-      pause(time?: number) {
-        if (!Object.keys(animationRefs.current).length) {
-          console.log("no refs found in array");
-          return;
-        }
-
-        const currentTime = time ?? 0;
-        Object.values(animationRefs.current).forEach((ref) =>
-          ref
-            ? ref?.pause(currentTime - start)
-            : console.log("ref is not found", ref),
-        );
+      synchronize(snapshot: PlaybackSnapshot) {
+        const isInRange =
+          start <= snapshot.currentTime && snapshot.currentTime <= end;
+        const lineSnapshot = {
+          ...snapshot,
+          currentTime: snapshot.currentTime - start,
+          state: isInRange ? snapshot.state : ("paused" as const),
+        };
+        Object.values(animationRefs.current).forEach((animationRef) => {
+          animationRef?.synchronize(lineSnapshot);
+        });
       },
     }));
 

--- a/packages/jukebox/src/components/public/lyrics/focused.tsx
+++ b/packages/jukebox/src/components/public/lyrics/focused.tsx
@@ -6,18 +6,14 @@ import { useAppContext } from "../AppContext";
 import type { Transition } from "framer-motion";
 import { motion } from "framer-motion";
 import { useActiveLyrcsRanges } from "../../../hooks/useActiveLyricsRanges";
-import {
-  forwardRef,
-  useCallback,
-  useEffect,
-  useImperativeHandle,
-  useRef,
-} from "react";
+import { forwardRef, useCallback, useEffect, useRef } from "react";
 import type { LyricsAnimationRef } from "./components/AnimationRef.type";
 import type { TimedSpanProps } from "./components/RubyLineRenderer";
 import { LineRenderer } from "./components/RubyLineRenderer";
 import { cn } from "@lyricova/components/utils";
 import { safeDuration } from "../../../frontendUtils/safeDuration";
+import { useWebAnimationController } from "../../../hooks/useWebAnimationController";
+import { readPlaybackSnapshot } from "../../../hooks/useMediaClock";
 
 const TRANSITION: Transition = {
   duration: 0.2,
@@ -29,54 +25,38 @@ const TimedSpanGenerator = (full: boolean) =>
     { startTime, endTime, children },
     ref,
   ) {
-    const webAnimationRef = useRef<Animation | null>(null);
-    const refCallback = useCallback(
-      (node: HTMLSpanElement | null) => {
-        if (node && node.style.opacity !== "1") {
-          node.style.opacity = "1";
-          const duration = safeDuration(startTime, endTime, 0.1, { children });
-          webAnimationRef.current = node.animate(
-            full
-              ? [
-                  { opacity: "0.3" },
-                  { opacity: "1", offset: 0.1 },
-                  { opacity: "1" },
-                ]
-              : [
-                  { opacity: "0.3" },
-                  { opacity: "1", offset: 0.1 },
-                  { opacity: "1", offset: 0.9 },
-                  { opacity: "0.6", offset: 1 },
-                ],
-            {
-              delay: startTime * 1000,
-              duration: duration * 1000,
-              fill: "both",
-              id: `static-mask-${startTime}-${endTime}-${children}`,
-            },
-          );
-        }
+    const createAnimation = useCallback(
+      (node: HTMLSpanElement) => {
+        const duration = safeDuration(startTime, endTime, 0.1, { children });
+        return node.animate(
+          full
+            ? [
+                { opacity: "0.3" },
+                { opacity: "1", offset: 0.1 },
+                { opacity: "1" },
+              ]
+            : [
+                { opacity: "0.3" },
+                { opacity: "1", offset: 0.1 },
+                { opacity: "1", offset: 0.9 },
+                { opacity: "0.6", offset: 1 },
+              ],
+          {
+            delay: startTime * 1000,
+            duration: duration * 1000,
+            fill: "both",
+            id: `static-mask-${startTime}-${endTime}-${children}`,
+          },
+        );
       },
-      [children, startTime, endTime],
+      [children, endTime, startTime],
     );
-    useImperativeHandle(ref, () => ({
-      resume(time?: number) {
-        const anim = webAnimationRef.current;
-        if (anim) {
-          anim.currentTime = time ? time * 1000 : 0;
-          if ((time ?? 0) <= endTime) anim.play();
-          else anim.pause();
-        }
-      },
-      pause(time?: number) {
-        const anim = webAnimationRef.current;
-        if (anim) {
-          anim.pause();
-          anim.currentTime = time ? time * 1000 : 0;
-        }
-      },
-    }));
-    return <span ref={refCallback}>{children}</span>;
+    const refCallback = useWebAnimationController(ref, createAnimation);
+    return (
+      <span ref={refCallback} style={{ opacity: 1 }}>
+        {children}
+      </span>
+    );
   });
 
 const TimedSpan = TimedSpanGenerator(true);
@@ -249,27 +229,16 @@ export function FocusedLyrics({
     lyrics.lines,
     playerRef,
   );
-  const playerStateRef = useRef(playerState);
-  playerStateRef.current = playerState;
 
   const animationRefs = useRef<(LyricsAnimationRef | null)[]>([]);
   useEffect(() => {
-    if (playerState.state === "playing") {
-      const currentTime =
-        (performance.now() - playerState.startingAt) / playerState.rate / 1000;
-      animationRefs.current.forEach((ref) => {
-        if (ref) {
-          ref.resume(currentTime);
-        }
-      });
-    } else {
-      animationRefs.current.forEach((ref) => {
-        if (ref) {
-          ref.pause(playerState.progress);
-        }
-      });
-    }
-  }, [playerState]);
+    const player = playerRef.current;
+    if (!player) return;
+    const snapshot = readPlaybackSnapshot(player);
+    animationRefs.current.forEach((animationRef) => {
+      animationRef?.synchronize(snapshot);
+    });
+  }, [currentFrame, playerRef, playerState]);
 
   const lines = lyrics.lines;
   const lang = lyrics.translationLanguages[transLangIdx ?? 0];
@@ -284,19 +253,12 @@ export function FocusedLyrics({
     (index: number) => (ref: LyricsAnimationRef | null) => {
       if (animationRefs.current[index] === ref) return;
       animationRefs.current[index] = ref;
-      if (ref) {
-        if (playerStateRef.current.state === "playing") {
-          const currentTime =
-            (performance.now() - playerStateRef.current.startingAt) /
-            playerStateRef.current.rate /
-            1000;
-          ref.resume(currentTime);
-        } else {
-          ref.pause(playerStateRef.current.progress);
-        }
+      const player = playerRef.current;
+      if (ref && player) {
+        ref.synchronize(readPlaybackSnapshot(player));
       }
     },
-    [],
+    [playerRef],
   );
 
   return (

--- a/packages/jukebox/src/components/public/lyrics/focused.tsx
+++ b/packages/jukebox/src/components/public/lyrics/focused.tsx
@@ -20,6 +20,9 @@ const TRANSITION: Transition = {
   ease: "easeOut",
 };
 
+/**
+ * Create a timed opacity span for full-line or per-syllable focused lyrics.
+ */
 const TimedSpanGenerator = (full: boolean) =>
   forwardRef<LyricsAnimationRef, TimedSpanProps>(function TimedSpan(
     { startTime, endTime, children },
@@ -219,6 +222,12 @@ interface Props {
   variant?: "plain" | "glow" | "glowPerSyllable";
 }
 
+/**
+ * Render the active focused lyric lines and synchronize their span animations.
+ *
+ * Each newly mounted line receives the current media snapshot before subsequent
+ * playback-state updates.
+ */
 export function FocusedLyrics({
   lyrics,
   transLangIdx,

--- a/packages/jukebox/src/components/public/lyrics/karaokeJa.tsx
+++ b/packages/jukebox/src/components/public/lyrics/karaokeJa.tsx
@@ -517,6 +517,12 @@ interface Props {
   blur?: boolean;
 }
 
+/**
+ * Render paginated Japanese karaoke lyrics with line-local GSAP progress.
+ *
+ * Timelines are rebuilt for each active line or countdown, synchronized from
+ * the media clock, and killed when replaced or unmounted.
+ */
 export function KaraokeJaLyrics({ lyrics }: Props) {
   const { playerRef } = useAppContext();
   const { ref: measureRef, width: containerWidth } =

--- a/packages/jukebox/src/components/public/lyrics/karaokeJa.tsx
+++ b/packages/jukebox/src/components/public/lyrics/karaokeJa.tsx
@@ -20,6 +20,8 @@ import FuriganaLyricsLine from "../../FuriganaLyricsLine";
 import gsap from "gsap";
 import { graphql } from "@lyricova/components/gql";
 import { cn } from "@lyricova/components/utils";
+import { readPlaybackSnapshot } from "../../../hooks/useMediaClock";
+import { synchronizeGsapTimeline } from "../../../hooks/useTrackwiseTimelineControl";
 
 type Timeline = gsap.core.Timeline;
 const COUNTDOWN_DURATION = 3;
@@ -148,24 +150,24 @@ function buildPages(lyrics: LyricsKitLyrics, duration: number): KaraokePage[] {
 // Line = -1 means countdown
 type KaraokeJaState =
   | {
-    /**
-     * Null to hide the page.
-     */
-    pageIdx: number;
-    /**
-     * Line Index.
-     * * -1 for countdown
-     * * `lines.length` to stay on the end of the page
-     * * `null` to stay on the beginning of the page
-     */
-    lineIdx: number | null;
-    showNext: boolean;
-  }
+      /**
+       * Null to hide the page.
+       */
+      pageIdx: number;
+      /**
+       * Line Index.
+       * * -1 for countdown
+       * * `lines.length` to stay on the end of the page
+       * * `null` to stay on the beginning of the page
+       */
+      lineIdx: number | null;
+      showNext: boolean;
+    }
   | {
-    pageIdx: null;
-    lineIdx: null;
-    showNext: false;
-  };
+      pageIdx: null;
+      lineIdx: null;
+      showNext: false;
+    };
 
 function useNicokaraLyricsState(
   lyrics: LyricsKitLyrics,
@@ -316,14 +318,14 @@ function LyricsLine({
 function LyricsLineHTML({ textLine, furiganaLine }: LyricsLineProps): string {
   const content = furiganaLine
     ? furiganaLine
-      .map(([text, ruby]) => {
-        if (text === ruby) {
-          return `<span>${text}</span>`;
-        } else {
-          return `<ruby>${text}<rp>(</rp><rt>${ruby}</rt><rp>)</rp></ruby>`;
-        }
-      })
-      .join("")
+        .map(([text, ruby]) => {
+          if (text === ruby) {
+            return `<span>${text}</span>`;
+          } else {
+            return `<ruby>${text}<rp>(</rp><rt>${ruby}</rt><rp>)</rp></ruby>`;
+          }
+        })
+        .join("")
     : `<span>${textLine}</span>`;
   return `<span style="position:relative;font-weight: 800;font-family: Source Han Serif,Noto Serif CJK,Noto Serif JP,serif;white-space:pre;">${content}</span>`;
 }
@@ -347,11 +349,11 @@ function buildPageClasses(
     const line = lyrics.lines[v];
     return line
       ? measureElement(
-        LyricsLineHTML({
-          textLine: line.content,
-          furiganaLine: furigana?.[v],
-        }),
-      ).width
+          LyricsLineHTML({
+            textLine: line.content,
+            furiganaLine: furigana?.[v],
+          }),
+        ).width
       : 0;
   });
 
@@ -612,7 +614,7 @@ export function KaraokeJaLyrics({ lyrics }: Props) {
     if (shouldUseTimelineFor !== timelineForRef.current) {
       if (timelineRef.current) timelineRef.current.kill();
       const tl = gsap.timeline({
-        paused: playerState.state === "paused",
+        paused: true,
       });
       timelineForRef.current = shouldUseTimelineFor;
       if (currentLine === null && activeSpan !== null)
@@ -703,17 +705,11 @@ export function KaraokeJaLyrics({ lyrics }: Props) {
     }
 
     // Controls the progress of timeline
-    const now = performance.now();
     const timeline = timelineRef.current;
-    if (timeline) {
+    const player = playerRef.current;
+    if (timeline && player) {
       const start = currentLineStartRef.current || 0;
-      if (playerState.state === "playing") {
-        const inlineProgress = (now - playerState.startingAt) / 1000 - start;
-        timeline.play(inlineProgress);
-      } else {
-        const inlineProgress = playerState.progress - start;
-        timeline.pause(inlineProgress);
-      }
+      synchronizeGsapTimeline(timeline, readPlaybackSnapshot(player), start);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
@@ -724,6 +720,13 @@ export function KaraokeJaLyrics({ lyrics }: Props) {
     currentLineStart,
     currentLine,
   ]);
+
+  useEffect(
+    () => () => {
+      timelineRef.current?.kill();
+    },
+    [],
+  );
 
   let node: React.ReactNode = <span>...</span>;
   if (sequenceQuery.error)

--- a/packages/jukebox/src/components/public/lyrics/karaokeJa.tsx
+++ b/packages/jukebox/src/components/public/lyrics/karaokeJa.tsx
@@ -644,7 +644,7 @@ export function KaraokeJaLyrics({ lyrics }: Props) {
               idx > 0 ? v.timeTag - tags[idx - 1].timeTag : v.timeTag;
             let start = idx > 0 ? tags[idx - 1].timeTag : 0;
             if (start === 0 && v.index !== 0) start = 0.0001;
-            let percentage = -2;
+            let percentage = 102;
             if (v.index > 0) percentage = percentages[v.index - 1];
             tl.to(
               activeSpan,

--- a/packages/jukebox/src/components/public/lyrics/pip.tsx
+++ b/packages/jukebox/src/components/public/lyrics/pip.tsx
@@ -212,7 +212,7 @@ export function PictureInPictureLyrics({ lyrics }: Props) {
 
   useEffect(() => {
     const canvas = canvasRef.current;
-    const timeline = gsap.timeline();
+    const timeline = gsap.timeline({ paused: true });
     if (!canvas) {
       console.error("canvas not ready", canvas);
       return;
@@ -310,7 +310,7 @@ export function PictureInPictureLyrics({ lyrics }: Props) {
     };
   }, []);
 
-  useTrackwiseTimelineControl(playerState, timeline);
+  useTrackwiseTimelineControl(playerRef, playerState, timeline);
 
   return (
     <div lang="ja">

--- a/packages/jukebox/src/components/public/lyrics/plain.tsx
+++ b/packages/jukebox/src/components/public/lyrics/plain.tsx
@@ -2,14 +2,7 @@ import type {
   LyricsKitLyrics,
   LyricsKitLyricsLine,
 } from "@lyricova/components/gql/schema";
-import {
-  forwardRef,
-  memo,
-  useCallback,
-  useEffect,
-  useImperativeHandle,
-  useRef,
-} from "react";
+import { forwardRef, memo, useCallback, useEffect } from "react";
 import { cn } from "@lyricova/components/utils";
 import type { RowRendererProps } from "./components/LyricsVirtualizer";
 import { LyricsVirtualizer } from "./components/LyricsVirtualizer";
@@ -18,50 +11,31 @@ import { LineRenderer } from "./components/RubyLineRenderer";
 import { safeDuration } from "../../../frontendUtils/safeDuration";
 import type { LyricsAnimationRef } from "./components/AnimationRef.type";
 import { useSpring, animated } from "@react-spring/web";
+import { useWebAnimationController } from "../../../hooks/useWebAnimationController";
 
 const TimedSpan = forwardRef<LyricsAnimationRef, TimedSpanProps>(
   function TimedSpan({ startTime, endTime, children }, ref) {
-    const webAnimationRef = useRef<Animation | null>(null);
-    const refCallback = useCallback(
-      (node: HTMLSpanElement | null) => {
-        if (node && node.style.opacity !== "1") {
-          node.style.opacity = "1";
-          const duration = safeDuration(startTime, endTime, 0.1, { children });
-          webAnimationRef.current = node.animate(
-            [
-              { opacity: "0.5" },
-              { opacity: "1", offset: 0.1 },
-              { opacity: "1" },
-            ],
-            {
-              delay: startTime * 1000,
-              duration: duration * 1000,
-              fill: "both",
-              id: `static-mask-${startTime}-${endTime}-${children}`,
-            },
-          );
-        }
+    const createAnimation = useCallback(
+      (node: HTMLSpanElement) => {
+        const duration = safeDuration(startTime, endTime, 0.1, { children });
+        return node.animate(
+          [{ opacity: "0.5" }, { opacity: "1", offset: 0.1 }, { opacity: "1" }],
+          {
+            delay: startTime * 1000,
+            duration: duration * 1000,
+            fill: "both",
+            id: `static-mask-${startTime}-${endTime}-${children}`,
+          },
+        );
       },
       [children, startTime, endTime],
     );
-    useImperativeHandle(ref, () => ({
-      resume(time?: number) {
-        const anim = webAnimationRef.current;
-        if (anim) {
-          anim.currentTime = time ? time * 1000 : 0;
-          if ((time ?? 0) <= endTime) anim.play();
-          else anim.pause();
-        }
-      },
-      pause(time?: number) {
-        const anim = webAnimationRef.current;
-        if (anim) {
-          anim.pause();
-          anim.currentTime = time ? time * 1000 : 0;
-        }
-      },
-    }));
-    return <span ref={refCallback}>{children}</span>;
+    const refCallback = useWebAnimationController(ref, createAnimation);
+    return (
+      <span ref={refCallback} style={{ opacity: 1 }}>
+        {children}
+      </span>
+    );
   },
 );
 

--- a/packages/jukebox/src/components/public/lyrics/plain.tsx
+++ b/packages/jukebox/src/components/public/lyrics/plain.tsx
@@ -13,6 +13,7 @@ import type { LyricsAnimationRef } from "./components/AnimationRef.type";
 import { useSpring, animated } from "@react-spring/web";
 import { useWebAnimationController } from "../../../hooks/useWebAnimationController";
 
+/** Render a timed opacity span controlled by its parent lyrics line. */
 const TimedSpan = forwardRef<LyricsAnimationRef, TimedSpanProps>(
   function TimedSpan({ startTime, endTime, children }, ref) {
     const createAnimation = useCallback(

--- a/packages/jukebox/src/components/public/lyrics/ringoll/LineRenderer.tsx
+++ b/packages/jukebox/src/components/public/lyrics/ringoll/LineRenderer.tsx
@@ -1,96 +1,70 @@
-import {
-  forwardRef,
-  memo,
-  useCallback,
-  useImperativeHandle,
-  useRef,
-} from "react";
+import { forwardRef, memo, useCallback } from "react";
 import type { LyricsKitLyricsLine } from "@lyricova/components/gql/schema";
 import type { LyricsAnimationRef } from "../components/AnimationRef.type";
 import type { TimedSpanProps } from "../components/RubyLineRenderer";
 import { LineRenderer } from "../components/RubyLineRenderer";
 import { safeDuration } from "../../../../frontendUtils/safeDuration";
+import { useWebAnimationController } from "../../../../hooks/useWebAnimationController";
 
 const FILLED_OPACITY = 100;
 const BLANK_OPACITY = 50;
 
 const TimedSpan = forwardRef<LyricsAnimationRef, TimedSpanProps>(
   function TimedSpan({ startTime, endTime, static: isStatic, children }, ref) {
-    // const spanRef = useRef<HTMLSpanElement>(null);
-    const webAnimationRefs = useRef<Animation[]>([]);
-    const refCallback = useCallback(
-      (node: HTMLSpanElement | null) => {
-        // webAnimationRefs.current.forEach(anim => anim.cancel());
+    const createAnimation = useCallback(
+      (node: HTMLSpanElement) => {
+        const duration = safeDuration(startTime, endTime, 0.1, {
+          children,
+        });
         if (isStatic) {
-          if (node && node.style.opacity !== "1") {
-            node.style.opacity = "1";
-            const duration = safeDuration(startTime, endTime, 0.1, {
-              children,
-            });
-            webAnimationRefs.current = [
-              node.animate(
-                [
-                  { opacity: "0.5" },
-                  { opacity: "1", offset: 0.1 },
-                  { opacity: "1", offset: 0.9 },
-                  { opacity: "0.5", offset: 1 },
-                ],
-                {
-                  delay: startTime * 1000,
-                  duration: duration * 1000,
-                  fill: "both",
-                  id: `static-mask-${startTime}-${endTime}-${children}`,
-                },
-              ),
-            ];
-          }
-        } else {
-          if (node && node.style.maskRepeat !== "no-repeat") {
-            node.style.maskImage = `linear-gradient(
-            to right, 
-            color-mix(in srgb, currentcolor ${FILLED_OPACITY}%, transparent) 50%, 
-            color-mix(in srgb, currentcolor ${BLANK_OPACITY}%, transparent) 50%
-          )`;
-            node.style.maskSize = "200% 100%";
-            node.style.maskRepeat = "no-repeat";
-            node.style.maskOrigin = "left";
-            const duration = safeDuration(startTime, endTime, 0.1, {
-              children,
-            });
-            webAnimationRefs.current = [
-              node.animate(
-                [{ maskPosition: "100% 0" }, { maskPosition: "0 0" }],
-                {
-                  delay: startTime * 1000,
-                  duration: duration * 1000,
-                  fill: "both",
-                  id: `mask-${startTime}-${endTime}-${children}`,
-                },
-              ),
-            ];
-          }
+          return node.animate(
+            [
+              { opacity: "0.5" },
+              { opacity: "1", offset: 0.1 },
+              { opacity: "1", offset: 0.9 },
+              { opacity: "0.5", offset: 1 },
+            ],
+            {
+              delay: startTime * 1000,
+              duration: duration * 1000,
+              fill: "both",
+              id: `static-mask-${startTime}-${endTime}-${children}`,
+            },
+          );
         }
+        return node.animate(
+          [{ maskPosition: "100% 0" }, { maskPosition: "0 0" }],
+          {
+            delay: startTime * 1000,
+            duration: duration * 1000,
+            fill: "both",
+            id: `mask-${startTime}-${endTime}-${children}`,
+          },
+        );
       },
       [children, endTime, isStatic, startTime],
     );
-    useImperativeHandle(ref, () => ({
-      resume(time?: number) {
-        // console.log("Resume at %o, %o", time ?? "current time", webAnimationRefs.current);
-        webAnimationRefs.current.forEach((anim) => {
-          anim.currentTime = time ? time * 1000 : 0;
-          if ((time ?? 0) <= endTime) anim.play();
-          else anim.pause();
-        });
-      },
-      pause(time?: number) {
-        // console.log("Pause at %o, %o", time ?? "current time", webAnimationRefs.current);
-        webAnimationRefs.current.forEach((anim) => {
-          anim.pause();
-          anim.currentTime = time ? time * 1000 : 0;
-        });
-      },
-    }));
-    return <span ref={refCallback}>{children}</span>;
+    const refCallback = useWebAnimationController(ref, createAnimation);
+    return (
+      <span
+        ref={refCallback}
+        style={
+          isStatic
+            ? { opacity: 1 }
+            : {
+                maskImage: `linear-gradient(
+                  to right,
+                  color-mix(in srgb, currentcolor ${FILLED_OPACITY}%, transparent) 50%,
+                  color-mix(in srgb, currentcolor ${BLANK_OPACITY}%, transparent) 50%
+                )`,
+                maskSize: "200% 100%",
+                maskRepeat: "no-repeat",
+              }
+        }
+      >
+        {children}
+      </span>
+    );
   },
 );
 

--- a/packages/jukebox/src/components/public/lyrics/ringoll/LineRenderer.tsx
+++ b/packages/jukebox/src/components/public/lyrics/ringoll/LineRenderer.tsx
@@ -9,6 +9,9 @@ import { useWebAnimationController } from "../../../../hooks/useWebAnimationCont
 const FILLED_OPACITY = 100;
 const BLANK_OPACITY = 50;
 
+/**
+ * Render a timed Ringoll span with either a static pulse or mask reveal.
+ */
 const TimedSpan = forwardRef<LyricsAnimationRef, TimedSpanProps>(
   function TimedSpan({ startTime, endTime, static: isStatic, children }, ref) {
     const createAnimation = useCallback(

--- a/packages/jukebox/src/components/public/lyrics/slanted.tsx
+++ b/packages/jukebox/src/components/public/lyrics/slanted.tsx
@@ -2,9 +2,10 @@ import type { LyricsKitLyrics } from "@lyricova/components/gql/schema";
 import { useAppContext } from "../AppContext";
 import { usePlainPlayerLyricsState } from "../../../hooks/usePlainPlayerLyricsState";
 import { useTrackwiseTimelineControl } from "../../../hooks/useTrackwiseTimelineControl";
-import { useMemo, useRef } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import gsap from "gsap";
 import { cn } from "@lyricova/components/utils";
+import { safeDuration } from "../../../frontendUtils/safeDuration";
 
 interface Props {
   lyrics: LyricsKitLyrics;
@@ -26,72 +27,82 @@ export function SlantedLyrics({ lyrics, transLangIdx }: Props) {
   const { playerState, currentFrameId, startTimes, endTimes } =
     usePlainPlayerLyricsState(lyrics, playerRef);
 
-  const timeline = useMemo(() => {
+  const [layoutVersion, setLayoutVersion] = useState(0);
+  const [timeline, setTimeline] = useState<gsap.core.Timeline | null>(null);
+
+  useEffect(() => {
+    const observedElements = [
+      container.current,
+      wrapper.current,
+      translationContainer.current,
+      translationWrapper.current,
+    ].filter((element): element is HTMLDivElement => element !== null);
+    if (!observedElements.length) return;
+
+    const observer = new ResizeObserver(() => {
+      setLayoutVersion((version) => version + 1);
+    });
+    observedElements.forEach((element) => observer.observe(element));
+    return () => observer.disconnect();
+  }, [hasTranslation, transLangIdx]);
+
+  useLayoutEffect(() => {
+    const mainWrapper = wrapper.current;
+    const mainContainer = container.current;
+    if (!mainWrapper || !mainContainer) return;
+
     const tl = gsap.timeline({
       paused: true,
     });
-    requestAnimationFrame(() => {
-      if (wrapper.current && container.current) {
-        const lines = wrapper.current.children;
-        tl.set(wrapper.current, { x: 0 }, 0);
-        for (let i = 0; i < lines.length; i++) {
-          const el = lines[i] as HTMLDivElement;
-          tl.to(
-            wrapper.current,
-            {
-              x: -(
-                el.offsetLeft -
-                container.current.offsetWidth / 2 +
-                el.offsetWidth
-              ),
-              duration: endTimes[i + 1] - startTimes[i],
-              ease: "none",
-            },
-            startTimes[i],
-          );
-        }
-      }
-      if (translationWrapper.current && translationContainer.current) {
-        const lines = translationWrapper.current.children;
-        tl.set(translationWrapper.current, { x: 0 }, 0);
-        for (let i = 0; i < lines.length; i++) {
-          const el = lines[i] as HTMLDivElement;
-          tl.to(
-            translationWrapper.current,
-            {
-              x: -(
-                el.offsetLeft -
-                translationContainer.current.offsetWidth / 2 +
-                el.offsetWidth
-              ),
-              duration: endTimes[i + 1] - startTimes[i],
-              ease: "none",
-            },
-            startTimes[i],
-          );
-        }
-      }
-      const now = performance.now();
-      if (playerState.state === "playing") {
-        const progress = (now - playerState.startingAt) / 1000;
-        timeline.play(progress, false);
-      } else {
-        timeline.pause(playerState.progress, false);
-      }
-    });
-    return tl;
+    const lines = mainWrapper.children;
+    tl.set(mainWrapper, { x: 0 }, 0);
+    for (let i = 0; i < lines.length; i++) {
+      const element = lines[i] as HTMLSpanElement;
+      tl.to(
+        mainWrapper,
+        {
+          x: -(
+            element.offsetLeft -
+            mainContainer.offsetWidth / 2 +
+            element.offsetWidth
+          ),
+          duration: safeDuration(startTimes[i] ?? 0, endTimes[i + 1] ?? 0),
+          ease: "none",
+        },
+        startTimes[i],
+      );
+    }
 
-    // Adding wrapper.current, translationWrapper.current for the timeline to change along with the lyrics.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    wrapper.current,
-    translationWrapper.current,
-    startTimes,
-    endTimes,
-    transLangIdx,
-  ]);
+    const translatedWrapper = translationWrapper.current;
+    const translatedContainer = translationContainer.current;
+    if (translatedWrapper && translatedContainer) {
+      const translatedLines = translatedWrapper.children;
+      tl.set(translatedWrapper, { x: 0 }, 0);
+      for (let i = 0; i < translatedLines.length; i++) {
+        const element = translatedLines[i] as HTMLSpanElement;
+        tl.to(
+          translatedWrapper,
+          {
+            x: -(
+              element.offsetLeft -
+              translatedContainer.offsetWidth / 2 +
+              element.offsetWidth
+            ),
+            duration: safeDuration(startTimes[i] ?? 0, endTimes[i + 1] ?? 0),
+            ease: "none",
+          },
+          startTimes[i],
+        );
+      }
+    }
 
-  useTrackwiseTimelineControl(playerState, timeline);
+    setTimeline(tl);
+    return () => {
+      tl.kill();
+    };
+  }, [endTimes, layoutVersion, startTimes, transLangIdx]);
+
+  useTrackwiseTimelineControl(playerRef, playerState, timeline);
 
   return (
     <div className="size-full overflow-hidden flex justify-center flex-col mask-x-from-[calc(100%_-_40px)] mask-x-to-100%">

--- a/packages/jukebox/src/components/public/lyrics/slanted.tsx
+++ b/packages/jukebox/src/components/public/lyrics/slanted.tsx
@@ -12,6 +12,12 @@ interface Props {
   transLangIdx?: number;
 }
 
+/**
+ * Render horizontally scrolling slanted lyrics on a track-wide GSAP timeline.
+ *
+ * Resize observations rebuild the layout-dependent timeline, which is then
+ * synchronized against the media element and disposed when replaced.
+ */
 export function SlantedLyrics({ lyrics, transLangIdx }: Props) {
   const { playerRef } = useAppContext();
   const container = useRef<HTMLDivElement>(null);

--- a/packages/jukebox/src/components/public/lyrics/stroke.tsx
+++ b/packages/jukebox/src/components/public/lyrics/stroke.tsx
@@ -152,6 +152,12 @@ interface LyricsLineElementProps {
   onProgressorReady?: (scene: Scene | null) => void;
 }
 
+/**
+ * Render one measured SVG lyric line and expose its paused Scene controller.
+ *
+ * The scene is rebuilt when wrapping or line content changes; its parent owns
+ * playback synchronization.
+ */
 function LyricsLineElement({
   line,
   duration,
@@ -271,6 +277,9 @@ interface Props {
   lyrics: LyricsKitLyrics;
 }
 
+/**
+ * Render stroke lyrics and synchronize the active line's Scene with playback.
+ */
 export function StrokeLyrics({ lyrics }: Props) {
   const { playerRef } = useAppContext();
   const { ref: measureRef, width } = useResizeObserver<HTMLDivElement>();

--- a/packages/jukebox/src/components/public/lyrics/stroke.tsx
+++ b/packages/jukebox/src/components/public/lyrics/stroke.tsx
@@ -5,12 +5,12 @@ import type {
 import { useAppContext } from "../AppContext";
 import { usePlainPlayerLyricsState } from "../../../hooks/usePlainPlayerLyricsState";
 import Balancer from "react-wrap-balancer";
-import type { RefObject } from "react";
 import type React from "react";
-import { useRef, useEffect } from "react";
+import { useCallback, useRef, useEffect, useState } from "react";
 import { useResizeObserver } from "../../../hooks/useResizeObserver";
 import { Scene } from "react-scenejs";
 import { cn } from "@lyricova/components/utils";
+import { readPlaybackSnapshot } from "../../../hooks/useMediaClock";
 
 const ANIMATION_THRESHOLD = 0.25;
 
@@ -149,7 +149,7 @@ interface LyricsLineElementProps {
   line: LyricsKitLyricsLine | null;
   duration: number;
   width: number;
-  progressorRef?: RefObject<Scene | null>;
+  onProgressorReady?: (scene: Scene | null) => void;
 }
 
 function LyricsLineElement({
@@ -157,12 +157,20 @@ function LyricsLineElement({
   duration,
   translationClassName,
   width,
-  progressorRef,
+  onProgressorReady,
 }: LyricsLineElementProps) {
   const textRef = useRef<SVGTextElement>(null);
   const sizerRef = useRef<HTMLDivElement>(null);
   const canvasRef = useRef<SVGSVGElement>(null);
+  const [progressorScene, setProgressorScene] = useState<Scene | null>(null);
   const animate = duration >= ANIMATION_THRESHOLD;
+  const setProgressor = useCallback(
+    (scene: Scene | null) => {
+      setProgressorScene(scene);
+      onProgressorReady?.(scene);
+    },
+    [onProgressorReady],
+  );
 
   useEffect(() => {
     if (textRef.current && sizerRef.current) {
@@ -203,9 +211,9 @@ function LyricsLineElement({
         );
       }
 
-      progressorRef?.current?.getItem().load(animate ? keyframes : {});
+      progressorScene?.getItem().load(animate ? keyframes : {});
     }
-  }, [animate, line, progressorRef, width]);
+  }, [animate, line, progressorScene, width]);
 
   return (
     <div>
@@ -219,14 +227,8 @@ function LyricsLineElement({
         {/* @ts-expect-error Scene is an JSX element. */}
         <Scene
           keyframes={animate ? keyframes : undefined}
-          ref={
-            animate
-              ? (scene) => {
-                if (progressorRef) progressorRef.current = scene;
-              }
-              : undefined
-          }
-          autoplay={true}
+          ref={animate ? setProgressor : undefined}
+          autoplay={false}
         >
           <svg
             width={width}
@@ -272,33 +274,35 @@ interface Props {
 export function StrokeLyrics({ lyrics }: Props) {
   const { playerRef } = useAppContext();
   const { ref: measureRef, width } = useResizeObserver<HTMLDivElement>();
-  const progressorRef = useRef<Scene>(null);
+  const [progressorScene, setProgressorScene] = useState<Scene | null>(null);
 
   const { currentFrame, currentFrameId, endTime, playerState } =
     usePlainPlayerLyricsState(lyrics, playerRef);
 
   useEffect(() => {
-    if (!progressorRef.current) return;
-    const progressorScene = progressorRef.current;
+    const player = playerRef.current;
+    if (!progressorScene || !player) return;
     if (currentFrameId >= lyrics.lines.length) {
       progressorScene.setTime("100%");
     } else {
-      const now = performance.now();
       const startTime = currentFrame?.start ?? 0;
-      if (playerState.state === "playing") {
-        const inlineProgress =
-          (now - playerState.startingAt) / 1000 - startTime;
-        progressorScene.setTime(inlineProgress);
+      const snapshot = readPlaybackSnapshot(player);
+      progressorScene.getItem().setPlaySpeed(snapshot.playbackRate);
+      progressorScene.setTime(snapshot.currentTime - startTime);
+      if (snapshot.state === "playing") {
         progressorScene.play();
       } else {
-        const inlineProgress = playerState.progress - startTime;
         progressorScene.pause();
-        progressorScene.setTime(inlineProgress);
       }
     }
-    // Player progress is not included to prevent animation loop.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [playerState.state, currentFrame, currentFrameId, lyrics.lines.length]);
+  }, [
+    currentFrame,
+    currentFrameId,
+    lyrics.lines.length,
+    playerRef,
+    playerState,
+    progressorScene,
+  ]);
 
   let lineElement: (width: number) => React.ReactNode | null = () => null;
   if (currentFrame !== null) {
@@ -310,7 +314,7 @@ export function StrokeLyrics({ lyrics }: Props) {
         line={currentFrame.data}
         duration={end - start}
         width={width}
-        progressorRef={progressorRef}
+        onProgressorReady={setProgressorScene}
       />
     );
   }

--- a/packages/jukebox/src/hooks/types.ts
+++ b/packages/jukebox/src/hooks/types.ts
@@ -24,7 +24,20 @@ export type PlayerState =
       state: "paused";
       /** Progress of the current player (seconds). */
       progress: number;
+      /** Playback rate to use when playback resumes. */
+      rate: number;
     };
+
+export interface PlaybackSnapshot {
+  currentTime: number;
+  duration: number;
+  playbackRate: number;
+  state: "playing" | "paused";
+}
+
+export interface PlaybackAnimationController {
+  synchronize: (snapshot: PlaybackSnapshot) => void;
+}
 
 export interface PlayerLyricsKeyframe<T> {
   /** Start of the frame, in seconds. */

--- a/packages/jukebox/src/hooks/types.ts
+++ b/packages/jukebox/src/hooks/types.ts
@@ -36,6 +36,7 @@ export interface PlaybackSnapshot {
 }
 
 export interface PlaybackAnimationController {
+  /** Seek the animation to a media snapshot and match its rate and play state. */
   synchronize: (snapshot: PlaybackSnapshot) => void;
 }
 

--- a/packages/jukebox/src/hooks/useAnimationFrame.spec.tsx
+++ b/packages/jukebox/src/hooks/useAnimationFrame.spec.tsx
@@ -1,0 +1,42 @@
+import { act, render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useAnimationFrame } from "./useAnimationFrame";
+
+describe("useAnimationFrame", () => {
+  it("schedules a one-shot frame when an inactive refresh key changes", () => {
+    const callbacks: FrameRequestCallback[] = [];
+    const onFrame = vi.fn();
+    const requestAnimationFrame = vi
+      .spyOn(window, "requestAnimationFrame")
+      .mockImplementation((callback) => {
+        callbacks.push(callback);
+        return callbacks.length;
+      });
+    const cancelAnimationFrame = vi
+      .spyOn(window, "cancelAnimationFrame")
+      .mockImplementation(() => {});
+
+    function Harness({ progress }: { progress: number }) {
+      useAnimationFrame(onFrame, false, progress);
+      return null;
+    }
+
+    const view = render(<Harness progress={0} />);
+    expect(callbacks).toHaveLength(1);
+
+    act(() => callbacks.shift()!(0));
+    expect(onFrame).toHaveBeenCalledTimes(1);
+    expect(callbacks).toHaveLength(0);
+
+    view.rerender(<Harness progress={5} />);
+    expect(callbacks).toHaveLength(1);
+
+    act(() => callbacks.shift()!(16));
+    expect(onFrame).toHaveBeenLastCalledWith(16);
+    expect(callbacks).toHaveLength(0);
+
+    view.unmount();
+    requestAnimationFrame.mockRestore();
+    cancelAnimationFrame.mockRestore();
+  });
+});

--- a/packages/jukebox/src/hooks/useAnimationFrame.ts
+++ b/packages/jukebox/src/hooks/useAnimationFrame.ts
@@ -3,6 +3,7 @@ import { useEffect, useRef } from "react";
 export function useAnimationFrame(
   callback: (timestamp: number) => void,
   active: boolean,
+  refreshKey?: unknown,
 ) {
   const callbackRef = useRef(callback);
   callbackRef.current = callback;
@@ -24,5 +25,5 @@ export function useAnimationFrame(
       disposed = true;
       if (animationFrame !== null) cancelAnimationFrame(animationFrame);
     };
-  }, [active]);
+  }, [active, refreshKey]);
 }

--- a/packages/jukebox/src/hooks/useAnimationFrame.ts
+++ b/packages/jukebox/src/hooks/useAnimationFrame.ts
@@ -1,0 +1,28 @@
+import { useEffect, useRef } from "react";
+
+export function useAnimationFrame(
+  callback: (timestamp: number) => void,
+  active: boolean,
+) {
+  const callbackRef = useRef(callback);
+  callbackRef.current = callback;
+
+  useEffect(() => {
+    let animationFrame: number | null = null;
+    let disposed = false;
+
+    const onFrame = (timestamp: number) => {
+      animationFrame = null;
+      callbackRef.current(timestamp);
+      if (active && !disposed) {
+        animationFrame = requestAnimationFrame(onFrame);
+      }
+    };
+
+    animationFrame = requestAnimationFrame(onFrame);
+    return () => {
+      disposed = true;
+      if (animationFrame !== null) cancelAnimationFrame(animationFrame);
+    };
+  }, [active]);
+}

--- a/packages/jukebox/src/hooks/useAnimationFrame.ts
+++ b/packages/jukebox/src/hooks/useAnimationFrame.ts
@@ -1,5 +1,11 @@
 import { useEffect, useRef } from "react";
 
+/**
+ * Run a callback on the next animation frame and continue while active.
+ *
+ * Changing `refreshKey` schedules a one-shot frame even while inactive, which
+ * allows paused media seeks to refresh their derived UI state.
+ */
 export function useAnimationFrame(
   callback: (timestamp: number) => void,
   active: boolean,

--- a/packages/jukebox/src/hooks/useLyricsState.ts
+++ b/packages/jukebox/src/hooks/useLyricsState.ts
@@ -9,7 +9,12 @@ import {
   useMediaClock,
 } from "./useMediaClock";
 
-/** Select the current lyrics line from the media element's playback clock. */
+/**
+ * Select the current lyrics line from the media element's playback clock.
+ *
+ * The optional callback runs only when the active line changes and receives
+ * the next line position, or the finite media duration for the final line.
+ */
 export function useLyricsState(
   playerRef: RefObject<HTMLAudioElement>,
   lyrics: LyricsKitLyrics,

--- a/packages/jukebox/src/hooks/useLyricsState.ts
+++ b/packages/jukebox/src/hooks/useLyricsState.ts
@@ -1,77 +1,56 @@
 import type { RefObject } from "react";
-import { useEffect } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import type { LyricsKitLyrics } from "@lyricova/components/gql/schema";
 import type { LyricsFrameCallback } from "./types";
 import { useNamedState } from "./useNamedState";
+import {
+  findActiveKeyframeIndex,
+  readPlaybackSnapshot,
+  useMediaClock,
+} from "./useMediaClock";
 
-/** Refactor useLyricsState using WebVTT Cue callbacks. */
+/** Select the current lyrics line from the media element's playback clock. */
 export function useLyricsState(
   playerRef: RefObject<HTMLAudioElement>,
   lyrics: LyricsKitLyrics,
   callback?: LyricsFrameCallback,
 ): number | null {
   const [line, setLine] = useNamedState<number | null>(null, "line");
+  const lineRef = useRef(line);
+  lineRef.current = line;
+  const startTimes = useMemo(
+    () => lyrics.lines.map((lyricsLine) => lyricsLine.position),
+    [lyrics.lines],
+  );
 
-  useEffect(() => {
-    if (!playerRef.current) return;
-    const player = playerRef.current;
+  const synchronizeLine = useCallback(
+    (snapshot: ReturnType<typeof readPlaybackSnapshot>) => {
+      const index = findActiveKeyframeIndex(startTimes, snapshot.currentTime);
+      const nextLine = index >= 0 ? index : null;
+      if (lineRef.current === nextLine) return;
 
-    // Create track
-    const track = document.createElement("track");
-    const uniqueId = Math.random().toString(36).substring(2, 15);
-    track.id = `lyricsState-${uniqueId}`;
-    track.kind = "subtitles";
-    track.label = `Lyrics State ${uniqueId}`;
-    track.src = "data:text/vtt;base64,V0VCVlRUCgoK";
-
-    // Add track
-    player.appendChild(track);
-    track.track.mode = "hidden";
-    // Workaround for Firefox
-    const textTrack = player.textTracks.getTrackById(track.id);
-    if (textTrack) textTrack.mode = "hidden";
-
-    const addCues = () => {
-      // Generate cues
-      if (lyrics?.lines?.length > 0 && lyrics.lines[0].position > 0) {
-        const cue = new VTTCue(0, lyrics.lines[0].position, "null,0");
-        cue.addEventListener("enter", () => {
-          setLine(null);
-          // console.log("WebWTT lyrics state enter", null);
-        });
-        track.track.addCue(cue);
-      }
-      lyrics.lines.forEach((line, index) => {
-        let nextLine: number =
-          lyrics.lines[index + 1]?.position ?? player.duration;
-        if (Number.isNaN(nextLine)) nextLine = 1e10;
-        const cue = new VTTCue(
-          line.position,
+      lineRef.current = nextLine;
+      setLine(nextLine);
+      const player = playerRef.current;
+      const lyricsLine = nextLine !== null ? lyrics.lines[nextLine] : undefined;
+      if (callback && player && nextLine !== null && lyricsLine) {
+        callback(
           nextLine,
-          `${index},${line.position},${line.content}`,
+          lyrics,
+          player,
+          lyricsLine.position,
+          lyrics.lines[nextLine + 1]?.position ??
+            (Number.isFinite(snapshot.duration) ? snapshot.duration : null),
         );
-        cue.addEventListener("enter", () => {
-          setLine(index);
-          // console.log("WebWTT lyrics state enter", index);
-          callback && callback(index, lyrics, player, line.position, nextLine);
-        });
-        track.track.addCue(cue);
-      });
-    };
-
-    if (player.readyState >= 2) {
-      // Set timeout to ensure the cues can be added properly.
-      setTimeout(addCues, 0);
-    } else {
-      player.addEventListener("loadedmetadata", addCues);
-    }
-
-    // Cleanup
-    return () => {
-      track?.parentElement?.removeChild(track);
-      player?.removeEventListener("loadedmetadata", addCues);
-    };
-  }, [callback, lyrics, playerRef, setLine]);
+      }
+    },
+    [callback, lyrics, playerRef, setLine, startTimes],
+  );
+  useMediaClock(playerRef, synchronizeLine);
+  useEffect(() => {
+    const player = playerRef.current;
+    if (player) synchronizeLine(readPlaybackSnapshot(player));
+  }, [playerRef, synchronizeLine]);
 
   return line;
 }

--- a/packages/jukebox/src/hooks/useMediaClock.spec.tsx
+++ b/packages/jukebox/src/hooks/useMediaClock.spec.tsx
@@ -1,0 +1,128 @@
+import { act, render, waitFor } from "@testing-library/react";
+import { useCallback, useRef } from "react";
+import { describe, expect, it, vi } from "vitest";
+import { findActiveKeyframeIndex, useMediaClock } from "./useMediaClock";
+import type { PlaybackSnapshot } from "./types";
+import { usePlayerLyricsState } from "./usePlayerLyricsState";
+
+describe("findActiveKeyframeIndex", () => {
+  it.each([
+    [[], 10, -1],
+    [[1, 2, 3], 0, -1],
+    [[1, 2, 3], 1, 0],
+    [[1, 2, 3], 2.5, 1],
+    [[1, 2, 3], 10, 2],
+    [[1, 2, 2, 3], 2, 2],
+  ] as const)("selects the frame at %s for %s", (starts, time, expected) => {
+    expect(findActiveKeyframeIndex(starts, time)).toBe(expected);
+  });
+});
+
+describe("useMediaClock", () => {
+  it("synchronizes immediately, responds to seeks, and cleans up frames", () => {
+    const snapshots: PlaybackSnapshot[] = [];
+    const animationFrames = new Map<number, FrameRequestCallback>();
+    let nextAnimationFrame = 1;
+    const requestAnimationFrame = vi
+      .spyOn(window, "requestAnimationFrame")
+      .mockImplementation((callback) => {
+        const id = nextAnimationFrame++;
+        animationFrames.set(id, callback);
+        return id;
+      });
+    const cancelAnimationFrame = vi
+      .spyOn(window, "cancelAnimationFrame")
+      .mockImplementation((id) => {
+        animationFrames.delete(id);
+      });
+
+    function Harness() {
+      const playerRef = useRef<HTMLAudioElement>(null);
+      useMediaClock(playerRef, (snapshot) => snapshots.push(snapshot));
+      return <audio ref={playerRef} />;
+    }
+
+    const view = render(<Harness />);
+    const player = view.container.querySelector("audio")!;
+    Object.defineProperties(player, {
+      currentTime: { configurable: true, writable: true, value: 4 },
+      duration: { configurable: true, value: 30 },
+      paused: { configurable: true, value: false },
+      playbackRate: { configurable: true, writable: true, value: 1.5 },
+      readyState: {
+        configurable: true,
+        writable: true,
+        value: HTMLMediaElement.HAVE_ENOUGH_DATA,
+      },
+    });
+
+    act(() => {
+      player.dispatchEvent(new Event("play"));
+    });
+    expect(snapshots.at(-1)).toMatchObject({
+      currentTime: 4,
+      duration: 30,
+      playbackRate: 1.5,
+      state: "playing",
+    });
+    expect(animationFrames).toHaveLength(1);
+
+    player.currentTime = 12;
+    act(() => {
+      player.dispatchEvent(new Event("seeked"));
+    });
+    expect(snapshots.at(-1)?.currentTime).toBe(12);
+
+    Object.defineProperty(player, "readyState", {
+      configurable: true,
+      value: HTMLMediaElement.HAVE_CURRENT_DATA,
+    });
+    act(() => {
+      player.dispatchEvent(new Event("waiting"));
+    });
+    expect(snapshots.at(-1)?.state).toBe("paused");
+    expect(animationFrames).toHaveLength(0);
+
+    view.unmount();
+    expect(animationFrames).toHaveLength(0);
+    expect(cancelAnimationFrame).toHaveBeenCalled();
+
+    requestAnimationFrame.mockRestore();
+    cancelAnimationFrame.mockRestore();
+  });
+
+  it("reselects a frame when a paused schedule changes", async () => {
+    function Harness({ startTimes }: { startTimes: number[] }) {
+      const playerRef = useRef<HTMLAudioElement>(null!);
+      const bindPlayer = useCallback((player: HTMLAudioElement | null) => {
+        playerRef.current = player as HTMLAudioElement;
+        if (!player) return;
+        Object.defineProperties(player, {
+          currentTime: { configurable: true, value: 6 },
+          duration: { configurable: true, value: 20 },
+          paused: { configurable: true, value: true },
+          playbackRate: { configurable: true, value: 1 },
+          readyState: {
+            configurable: true,
+            value: HTMLMediaElement.HAVE_ENOUGH_DATA,
+          },
+        });
+      }, []);
+      const state = usePlayerLyricsState(
+        startTimes.map((start, index) => ({ data: index, start })),
+        playerRef,
+      );
+      return (
+        <>
+          <audio ref={bindPlayer} />
+          <output>{state.currentFrameId}</output>
+        </>
+      );
+    }
+
+    const view = render(<Harness startTimes={[1, 5]} />);
+    await waitFor(() => expect(view.getByRole("status").textContent).toBe("1"));
+    view.rerender(<Harness startTimes={[1, 7]} />);
+    await waitFor(() => expect(view.getByRole("status").textContent).toBe("0"));
+  });
+});

--- a/packages/jukebox/src/hooks/useMediaClock.ts
+++ b/packages/jukebox/src/hooks/useMediaClock.ts
@@ -18,6 +18,11 @@ const MEDIA_EVENTS: (keyof HTMLMediaElementEventMap)[] = [
   "waiting",
 ];
 
+/**
+ * Read the media element's current timing state for animation synchronization.
+ *
+ * Media that is paused, ended, or lacks future data is reported as paused.
+ */
 export function readPlaybackSnapshot(
   player: HTMLMediaElement,
 ): PlaybackSnapshot {
@@ -34,6 +39,11 @@ export function readPlaybackSnapshot(
   };
 }
 
+/**
+ * Find the last entry in sorted `startTimes` that is not after `currentTime`.
+ *
+ * @returns The matching index, or `-1` before the first keyframe.
+ */
 export function findActiveKeyframeIndex(
   startTimes: readonly number[],
   currentTime: number,
@@ -53,6 +63,13 @@ export function findActiveKeyframeIndex(
   return low - 1;
 }
 
+/**
+ * Emit media timing snapshots on relevant media events and during playback.
+ *
+ * The hook synchronizes immediately, resumes after visibility changes, and
+ * cancels its animation frame on pause or unmount. Continuous animation frames
+ * can be disabled for consumers that only need event-driven state.
+ */
 export function useMediaClock(
   playerRef: RefObject<HTMLMediaElement | null>,
   onSnapshot: (snapshot: PlaybackSnapshot) => void,

--- a/packages/jukebox/src/hooks/useMediaClock.ts
+++ b/packages/jukebox/src/hooks/useMediaClock.ts
@@ -1,0 +1,123 @@
+import type { RefObject } from "react";
+import { useEffect, useRef } from "react";
+import type { PlaybackSnapshot } from "./types";
+
+const MEDIA_EVENTS: (keyof HTMLMediaElementEventMap)[] = [
+  "durationchange",
+  "emptied",
+  "loadedmetadata",
+  "canplay",
+  "pause",
+  "play",
+  "playing",
+  "ratechange",
+  "seeked",
+  "seeking",
+  "stalled",
+  "timeupdate",
+  "waiting",
+];
+
+export function readPlaybackSnapshot(
+  player: HTMLMediaElement,
+): PlaybackSnapshot {
+  return {
+    currentTime: Number.isFinite(player.currentTime) ? player.currentTime : 0,
+    duration: player.duration,
+    playbackRate: player.playbackRate,
+    state:
+      player.paused ||
+      player.ended ||
+      player.readyState < HTMLMediaElement.HAVE_FUTURE_DATA
+        ? "paused"
+        : "playing",
+  };
+}
+
+export function findActiveKeyframeIndex(
+  startTimes: readonly number[],
+  currentTime: number,
+): number {
+  let low = 0;
+  let high = startTimes.length;
+
+  while (low < high) {
+    const middle = low + Math.floor((high - low) / 2);
+    if (startTimes[middle]! <= currentTime) {
+      low = middle + 1;
+    } else {
+      high = middle;
+    }
+  }
+
+  return low - 1;
+}
+
+export function useMediaClock(
+  playerRef: RefObject<HTMLMediaElement | null>,
+  onSnapshot: (snapshot: PlaybackSnapshot) => void,
+  { animationFrames = true }: { animationFrames?: boolean } = {},
+) {
+  const onSnapshotRef = useRef(onSnapshot);
+  onSnapshotRef.current = onSnapshot;
+
+  useEffect(() => {
+    const player = playerRef.current;
+    if (!player) return;
+
+    let animationFrame: number | null = null;
+
+    const emit = () => {
+      const snapshot = readPlaybackSnapshot(player);
+      onSnapshotRef.current(snapshot);
+      return snapshot;
+    };
+    const stopAnimationFrames = () => {
+      if (animationFrame !== null) {
+        cancelAnimationFrame(animationFrame);
+        animationFrame = null;
+      }
+    };
+    const onAnimationFrame = () => {
+      animationFrame = null;
+      const snapshot = emit();
+      if (snapshot.state === "playing") {
+        animationFrame = requestAnimationFrame(onAnimationFrame);
+      }
+    };
+    const startAnimationFrames = () => {
+      if (
+        animationFrames &&
+        animationFrame === null &&
+        readPlaybackSnapshot(player).state === "playing"
+      ) {
+        animationFrame = requestAnimationFrame(onAnimationFrame);
+      }
+    };
+    const synchronize = () => {
+      const snapshot = emit();
+      if (snapshot.state === "paused") {
+        stopAnimationFrames();
+      } else {
+        startAnimationFrames();
+      }
+    };
+    const onVisibilityChange = () => {
+      if (document.visibilityState === "visible") synchronize();
+    };
+
+    MEDIA_EVENTS.forEach((event) =>
+      player.addEventListener(event, synchronize),
+    );
+    document.addEventListener("visibilitychange", onVisibilityChange);
+    synchronize();
+
+    return () => {
+      stopAnimationFrames();
+      MEDIA_EVENTS.forEach((event) =>
+        player.removeEventListener(event, synchronize),
+      );
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+    };
+  }, [animationFrames, playerRef]);
+}

--- a/packages/jukebox/src/hooks/usePlayerLyricsState.ts
+++ b/packages/jukebox/src/hooks/usePlayerLyricsState.ts
@@ -39,20 +39,38 @@ export function usePlayerLyricsState<T>(
 
   /**
    * `endTimes[i + 1]` is when frame `i` ends, in seconds.
+   * Each slot holds the next *finite* keyframe start (or the track end),
+   * skipping over any `NaN`/`Infinity` starts.
    * Last value is the end of the track.
    */
   const endTimes = useMemo(() => {
-    const endTimes = [];
-    keyframes.forEach((v, idx) => {
-      endTimes[idx] = v.start;
-    });
+    const n = keyframes.length;
+    const result: number[] = new Array(n + 1);
 
-    if (mediaDuration !== null) endTimes[keyframes.length] = mediaDuration;
-    else if (keyframes.length > 0)
-      endTimes[keyframes.length] = keyframes[keyframes.length - 1]!.start + 10;
-    else endTimes[keyframes.length] = 0;
+    if (mediaDuration !== null) {
+      result[n] = mediaDuration;
+    } else if (n > 0) {
+      let lastFiniteStart = 0;
+      for (let i = n - 1; i >= 0; i--) {
+        if (Number.isFinite(keyframes[i]!.start)) {
+          lastFiniteStart = keyframes[i]!.start;
+          break;
+        }
+      }
+      result[n] = lastFiniteStart + 10;
+    } else {
+      result[n] = 0;
+    }
 
-    return endTimes;
+    let nextFinite = result[n];
+    for (let i = n - 1; i >= 0; i--) {
+      if (Number.isFinite(keyframes[i]!.start)) {
+        nextFinite = keyframes[i]!.start;
+      }
+      result[i] = nextFinite;
+    }
+
+    return result;
   }, [keyframes, mediaDuration]);
 
   const startTimes = useMemo(() => keyframes.map((v) => v.start), [keyframes]);

--- a/packages/jukebox/src/hooks/usePlayerLyricsState.ts
+++ b/packages/jukebox/src/hooks/usePlayerLyricsState.ts
@@ -9,7 +9,13 @@ import {
   useMediaClock,
 } from "./useMediaClock";
 
-/** Select the current lyrics frame from the media element's playback clock. */
+/**
+ * Select the current lyrics frame from the media element's playback clock.
+ *
+ * Invalid start times are excluded from scheduling while returned frame IDs
+ * still refer to the original keyframe order. The final frame ends at the
+ * finite media duration when it is available.
+ */
 export function usePlayerLyricsState<T>(
   keyframes: PlayerLyricsKeyframe<T>[],
   playerRef: RefObject<HTMLAudioElement>,

--- a/packages/jukebox/src/hooks/usePlayerLyricsState.ts
+++ b/packages/jukebox/src/hooks/usePlayerLyricsState.ts
@@ -1,10 +1,15 @@
 import type { RefObject } from "react";
-import { useMemo, useEffect } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import type { PlayerLyricsKeyframe, PlayerLyricsState } from "./types";
 import { useNamedState } from "./useNamedState";
 import { usePlayerState } from "./usePlayerState";
+import {
+  findActiveKeyframeIndex,
+  readPlaybackSnapshot,
+  useMediaClock,
+} from "./useMediaClock";
 
-/** Refactor usePlayerLyricsState using WebVTT Cue callbacks. */
+/** Select the current lyrics frame from the media element's playback clock. */
 export function usePlayerLyricsState<T>(
   keyframes: PlayerLyricsKeyframe<T>[],
   playerRef: RefObject<HTMLAudioElement>,
@@ -19,6 +24,12 @@ export function usePlayerLyricsState<T>(
     -1,
     "currentFrameId",
   );
+  const [mediaDuration, setMediaDuration] = useState(() => {
+    const duration = playerRef.current?.duration;
+    return duration !== undefined && Number.isFinite(duration)
+      ? duration
+      : null;
+  });
 
   /**
    * `endTimes[i + 1]` is when frame `i` ends, in seconds.
@@ -30,77 +41,57 @@ export function usePlayerLyricsState<T>(
       endTimes[idx] = v.start;
     });
 
-    if (playerRef.current)
-      endTimes[keyframes.length] = playerRef.current.duration;
+    if (mediaDuration !== null) endTimes[keyframes.length] = mediaDuration;
     else if (keyframes.length > 0)
       endTimes[keyframes.length] = keyframes[keyframes.length - 1]!.start + 10;
     else endTimes[keyframes.length] = 0;
 
     return endTimes;
-  }, [keyframes, playerRef]);
+  }, [keyframes, mediaDuration]);
 
   const startTimes = useMemo(() => keyframes.map((v) => v.start), [keyframes]);
+  const schedulableKeyframes = useMemo(
+    () =>
+      startTimes
+        .map((start, index) => ({ index, start }))
+        .filter(({ start }) => Number.isFinite(start))
+        .toSorted(
+          (left, right) => left.start - right.start || left.index - right.index,
+        ),
+    [startTimes],
+  );
+  const schedulableStartTimes = useMemo(
+    () => schedulableKeyframes.map(({ start }) => start),
+    [schedulableKeyframes],
+  );
 
-  useEffect(() => {
-    if (!playerRef.current) return;
-    const player = playerRef.current;
-
-    // Create track
-    const track = document.createElement("track");
-    const uniqueId = Math.random().toString(36).substring(2, 15);
-    track.id = `playerLyricsState-${uniqueId}`;
-    track.kind = "subtitles";
-    track.label = `Player Lyrics State ${uniqueId}`;
-    track.src = "data:text/vtt;base64,V0VCVlRUCgoK";
-
-    // Add track
-    player.appendChild(track);
-    track.track.mode = "hidden";
-    // Workaround for Firefox
-    const textTrack = player.textTracks.getTrackById(track.id);
-    if (textTrack) textTrack.mode = "hidden";
-
-    const addCues = () => {
-      // Generate cues
-      const firstStartTime = startTimes[0];
-      if (firstStartTime !== undefined && firstStartTime > 0) {
-        const cue = new VTTCue(0, firstStartTime, `-1,0,${firstStartTime}`);
-        cue.addEventListener("enter", () => {
-          setCurrentFrameId(-1);
-          // console.log("WebWTT lyrics state enter", -1);
-        });
-        track.track.addCue(cue);
-      }
-      startTimes.forEach((startTime, index) => {
-        let endTime: number = endTimes[index + 1] ?? player.duration;
-        if (isNaN(startTime)) return;
-        if (isNaN(endTime)) endTime = 1e10;
-        const cue = new VTTCue(
-          startTime,
-          endTime,
-          `${index},${startTime},${endTime}`,
+  const synchronizeFrame = useCallback(
+    (snapshot: ReturnType<typeof readPlaybackSnapshot>) => {
+      if (Number.isFinite(snapshot.duration)) {
+        setMediaDuration((duration) =>
+          duration === snapshot.duration ? duration : snapshot.duration,
         );
-        cue.addEventListener("enter", () => {
-          setCurrentFrameId(index);
-          // console.log("WebWTT lyrics state enter", index);
-        });
-        track.track.addCue(cue);
-      });
-    };
+      }
 
-    if (player.readyState >= 2) {
-      // Set timeout to ensure the cues can be added properly.
-      setTimeout(addCues, 0);
-    } else {
-      player.addEventListener("loadedmetadata", addCues);
-    }
-
-    // Cleanup
-    return () => {
-      track?.parentElement?.removeChild(track);
-      player?.removeEventListener("loadedmetadata", addCues);
-    };
-  }, [startTimes, endTimes, playerRef, setCurrentFrameId]);
+      const scheduleIndex = findActiveKeyframeIndex(
+        schedulableStartTimes,
+        snapshot.currentTime,
+      );
+      const nextFrameId =
+        scheduleIndex >= 0
+          ? (schedulableKeyframes[scheduleIndex]?.index ?? -1)
+          : -1;
+      setCurrentFrameId((frameId) =>
+        frameId === nextFrameId ? frameId : nextFrameId,
+      );
+    },
+    [schedulableKeyframes, schedulableStartTimes, setCurrentFrameId],
+  );
+  useMediaClock(playerRef, synchronizeFrame);
+  useEffect(() => {
+    const player = playerRef.current;
+    if (player) synchronizeFrame(readPlaybackSnapshot(player));
+  }, [playerRef, synchronizeFrame]);
 
   return {
     playerState,

--- a/packages/jukebox/src/hooks/usePlayerLyricsTypingState.ts
+++ b/packages/jukebox/src/hooks/usePlayerLyricsTypingState.ts
@@ -165,7 +165,7 @@ export function usePlayerLyricsTypingState(
     typingElementRef,
   ]);
 
-  useTrackwiseTimelineControl(playerState, timeline);
+  useTrackwiseTimelineControl(playerRef, playerState, timeline);
 
   return { ...state, timeline, sequenceQuery };
 }

--- a/packages/jukebox/src/hooks/usePlayerState.ts
+++ b/packages/jukebox/src/hooks/usePlayerState.ts
@@ -1,32 +1,38 @@
 import type { RefObject } from "react";
-import { useCallback, useEffect, useRef } from "react";
 import type { PlayerState } from "./types";
 import { useNamedState } from "./useNamedState";
+import { useMediaClock } from "./useMediaClock";
 
 export function usePlayerState(playerRef: RefObject<HTMLAudioElement>) {
   const [playerState, setPlayerState] = useNamedState<PlayerState>(
-    { state: "paused", progress: 0 },
+    { state: "paused", progress: 0, rate: 1 },
     "playerState",
   );
-  const playerStateRef = useRef<PlayerState>(playerState);
-  playerStateRef.current = playerState;
 
-  const updatePlayerState = useCallback(() => {
-    const player = playerRef.current;
-    if (!player) return;
-    if (player.paused) {
-      setPlayerState((v) => {
-        if (
-          v.state === "paused" &&
-          Math.abs(v.progress - player.currentTime) < 0.01
-        ) {
-          return v;
-        }
-        return { state: "paused", progress: player.currentTime };
-      });
-    } else {
-      const rate = player.playbackRate;
-      const startingAt = performance.now() - (player.currentTime * 1000) / rate;
+  useMediaClock(
+    playerRef,
+    (snapshot) => {
+      if (snapshot.state === "paused") {
+        setPlayerState((value) => {
+          if (
+            value.state === "paused" &&
+            Math.abs(value.progress - snapshot.currentTime) < 0.01 &&
+            value.rate === snapshot.playbackRate
+          ) {
+            return value;
+          }
+          return {
+            state: "paused",
+            progress: snapshot.currentTime,
+            rate: snapshot.playbackRate,
+          };
+        });
+        return;
+      }
+
+      const rate = snapshot.playbackRate;
+      const startingAt =
+        performance.now() - (snapshot.currentTime * 1000) / rate;
       setPlayerState((v) => {
         if (
           v.state === "playing" &&
@@ -37,29 +43,9 @@ export function usePlayerState(playerRef: RefObject<HTMLAudioElement>) {
         }
         return { state: "playing", startingAt, rate };
       });
-    }
-  }, [playerRef, setPlayerState]);
-
-  // Register event listeners
-  useEffect(() => {
-    const player = playerRef.current;
-    if (!player) return;
-
-    player.addEventListener("play", updatePlayerState);
-    player.addEventListener("timeupdate", updatePlayerState);
-    player.addEventListener("pause", updatePlayerState);
-    player.addEventListener("seeked", updatePlayerState);
-    player.addEventListener("ratechange", updatePlayerState);
-    updatePlayerState();
-
-    return () => {
-      player.removeEventListener("play", updatePlayerState);
-      player.removeEventListener("timeupdate", updatePlayerState);
-      player.removeEventListener("pause", updatePlayerState);
-      player.removeEventListener("seeked", updatePlayerState);
-      player.removeEventListener("ratechange", updatePlayerState);
-    };
-  }, [playerRef, updatePlayerState]);
+    },
+    { animationFrames: false },
+  );
 
   return playerState;
 }

--- a/packages/jukebox/src/hooks/usePlayerState.ts
+++ b/packages/jukebox/src/hooks/usePlayerState.ts
@@ -3,6 +3,12 @@ import type { PlayerState } from "./types";
 import { useNamedState } from "./useNamedState";
 import { useMediaClock } from "./useMediaClock";
 
+/**
+ * Derive stable paused or playing state from an audio element's media clock.
+ *
+ * Paused state preserves exact progress and playback rate; playing state uses
+ * a performance-time origin while suppressing insignificant event updates.
+ */
 export function usePlayerState(playerRef: RefObject<HTMLAudioElement>) {
   const [playerState, setPlayerState] = useNamedState<PlayerState>(
     { state: "paused", progress: 0, rate: 1 },

--- a/packages/jukebox/src/hooks/useTrackwiseTimelineControl.spec.ts
+++ b/packages/jukebox/src/hooks/useTrackwiseTimelineControl.spec.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from "vitest";
+import { synchronizeGsapTimeline } from "./useTrackwiseTimelineControl";
+
+function timelineStub() {
+  return {
+    pause: vi.fn(),
+    play: vi.fn(),
+    timeScale: vi.fn(),
+  } as unknown as gsap.core.Timeline;
+}
+
+describe("synchronizeGsapTimeline", () => {
+  it("seeks and plays at the media playback rate", () => {
+    const timeline = timelineStub();
+
+    synchronizeGsapTimeline(timeline, {
+      currentTime: 12,
+      duration: 20,
+      playbackRate: 1.5,
+      state: "playing",
+    });
+
+    expect(timeline.timeScale).toHaveBeenCalledWith(1.5);
+    expect(timeline.play).toHaveBeenCalledWith(12, false);
+  });
+
+  it("applies offsets and pauses", () => {
+    const timeline = timelineStub();
+
+    synchronizeGsapTimeline(
+      timeline,
+      {
+        currentTime: 12,
+        duration: 20,
+        playbackRate: 0.75,
+        state: "paused",
+      },
+      10,
+    );
+
+    expect(timeline.timeScale).toHaveBeenCalledWith(0.75);
+    expect(timeline.pause).toHaveBeenCalledWith(2, false);
+  });
+});

--- a/packages/jukebox/src/hooks/useTrackwiseTimelineControl.ts
+++ b/packages/jukebox/src/hooks/useTrackwiseTimelineControl.ts
@@ -1,33 +1,35 @@
+import type { RefObject } from "react";
 import { useEffect } from "react";
-import type { PlayerState } from "./types";
+import type { PlaybackSnapshot, PlayerState } from "./types";
+import { readPlaybackSnapshot } from "./useMediaClock";
 
 type Timeline = gsap.core.Timeline;
+
+export function synchronizeGsapTimeline(
+  timeline: Timeline,
+  snapshot: PlaybackSnapshot,
+  offset = 0,
+) {
+  const progress = snapshot.currentTime - offset;
+  timeline.timeScale(snapshot.playbackRate);
+  if (snapshot.state === "playing") {
+    timeline.play(progress, false);
+  } else {
+    timeline.pause(progress, false);
+  }
+}
 
 /**
  * Control a GSAP timeline which covers the entire track according to the player state.
  */
 export function useTrackwiseTimelineControl(
+  playerRef: RefObject<HTMLMediaElement>,
   playerState: PlayerState,
   timeline: Timeline | null,
 ) {
-  // Controls the progress of timeline
   useEffect(() => {
-    const now = performance.now();
-    if (!timeline) return;
-    if (playerState.state === "playing") {
-      const progress = (now - playerState.startingAt) / 1000;
-      timeline.play(progress, false);
-    } else {
-      timeline.pause(playerState.progress, false);
-    }
-  }, [playerState, timeline]);
-
-  // Kill a timeline when its lifespan ends.
-  useEffect(() => {
-    const tl = timeline;
-    if (!tl) return;
-    return () => {
-      tl.kill();
-    };
-  }, [timeline]);
+    const player = playerRef.current;
+    if (!player || !timeline) return;
+    synchronizeGsapTimeline(timeline, readPlaybackSnapshot(player));
+  }, [playerRef, playerState, timeline]);
 }

--- a/packages/jukebox/src/hooks/useTrackwiseTimelineControl.ts
+++ b/packages/jukebox/src/hooks/useTrackwiseTimelineControl.ts
@@ -5,6 +5,11 @@ import { readPlaybackSnapshot } from "./useMediaClock";
 
 type Timeline = gsap.core.Timeline;
 
+/**
+ * Seek a GSAP timeline to a media snapshot and match its rate and play state.
+ *
+ * @param offset Seconds to subtract when the timeline is local to a segment.
+ */
 export function synchronizeGsapTimeline(
   timeline: Timeline,
   snapshot: PlaybackSnapshot,
@@ -20,7 +25,10 @@ export function synchronizeGsapTimeline(
 }
 
 /**
- * Control a GSAP timeline which covers the entire track according to the player state.
+ * Synchronize a track-wide GSAP timeline with the media element.
+ *
+ * `playerState` invalidates the effect, while the media element remains the
+ * source of truth for the exact time, playback rate, and paused state.
  */
 export function useTrackwiseTimelineControl(
   playerRef: RefObject<HTMLMediaElement>,

--- a/packages/jukebox/src/hooks/useWebAnimationController.spec.tsx
+++ b/packages/jukebox/src/hooks/useWebAnimationController.spec.tsx
@@ -1,0 +1,111 @@
+import { act, render } from "@testing-library/react";
+import { createRef, forwardRef, StrictMode, useCallback } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import type { PlaybackAnimationController } from "./types";
+import { useWebAnimationController } from "./useWebAnimationController";
+
+type AnimationStub = Animation & {
+  cancel: ReturnType<typeof vi.fn>;
+  pause: ReturnType<typeof vi.fn>;
+  play: ReturnType<typeof vi.fn>;
+};
+
+const animations: AnimationStub[] = [];
+
+function createAnimationStub(): AnimationStub {
+  const animation = {
+    cancel: vi.fn(),
+    currentTime: null,
+    pause: vi.fn(),
+    play: vi.fn(),
+    playbackRate: 1,
+    ready: Promise.resolve(),
+    effect: {
+      getComputedTiming: () => ({ endTime: 10_000 }),
+    } as AnimationEffect,
+  } as unknown as AnimationStub;
+  animations.push(animation);
+  return animation;
+}
+
+const Harness = forwardRef<
+  PlaybackAnimationController,
+  { animationVersion: number }
+>(function Harness({ animationVersion }, ref) {
+  const createAnimation = useCallback(() => {
+    void animationVersion;
+    return createAnimationStub();
+  }, [animationVersion]);
+  const animationRef = useWebAnimationController<HTMLSpanElement>(
+    ref,
+    createAnimation,
+  );
+  return <span ref={animationRef}>lyrics</span>;
+});
+
+afterEach(() => {
+  animations.length = 0;
+});
+
+describe("useWebAnimationController", () => {
+  it("synchronizes and recreates an animation on the same node", () => {
+    const controller = createRef<PlaybackAnimationController>();
+    const view = render(<Harness ref={controller} animationVersion={1} />);
+    const firstAnimation = animations.at(-1)!;
+
+    act(() => {
+      controller.current?.synchronize({
+        currentTime: 2.5,
+        duration: 10,
+        playbackRate: 1.25,
+        state: "playing",
+      });
+    });
+    expect(firstAnimation.currentTime).toBe(2500);
+    expect(firstAnimation.playbackRate).toBe(1.25);
+    expect(firstAnimation.play).toHaveBeenCalled();
+
+    view.rerender(<Harness ref={controller} animationVersion={2} />);
+    const secondAnimation = animations.at(-1)!;
+    expect(secondAnimation).not.toBe(firstAnimation);
+    expect(firstAnimation.cancel).toHaveBeenCalled();
+    expect(secondAnimation.currentTime).toBe(2500);
+
+    view.unmount();
+    expect(secondAnimation.cancel).toHaveBeenCalled();
+  });
+
+  it("cleans up animations during Strict Mode ref replay", () => {
+    const controller = createRef<PlaybackAnimationController>();
+    const view = render(
+      <StrictMode>
+        <Harness ref={controller} animationVersion={1} />
+      </StrictMode>,
+    );
+
+    view.unmount();
+    expect(animations.length).toBeGreaterThan(0);
+    expect(
+      animations.every((animation) => animation.cancel.mock.calls.length),
+    ).toBe(true);
+  });
+
+  it("keeps a completed animation at its filled end state", () => {
+    const controller = createRef<PlaybackAnimationController>();
+    render(<Harness ref={controller} animationVersion={1} />);
+    const animation = animations.at(-1)!;
+
+    act(() => {
+      controller.current?.synchronize({
+        currentTime: 12,
+        duration: 20,
+        playbackRate: 1,
+        state: "playing",
+      });
+    });
+
+    expect(animation.currentTime).toBe(12_000);
+    expect(animation.pause).toHaveBeenCalled();
+    expect(animation.play).not.toHaveBeenCalled();
+  });
+});

--- a/packages/jukebox/src/hooks/useWebAnimationController.ts
+++ b/packages/jukebox/src/hooks/useWebAnimationController.ts
@@ -1,0 +1,75 @@
+import type { ForwardedRef, RefCallback } from "react";
+import { useCallback, useImperativeHandle, useRef } from "react";
+import type { PlaybackAnimationController, PlaybackSnapshot } from "./types";
+
+function synchronizeAnimation(
+  animation: Animation,
+  snapshot: PlaybackSnapshot,
+) {
+  animation.playbackRate = snapshot.playbackRate;
+  animation.currentTime = snapshot.currentTime * 1000;
+  const effectEnd = animation.effect?.getComputedTiming().endTime;
+  const isComplete =
+    typeof effectEnd === "number" &&
+    animation.currentTime !== null &&
+    animation.currentTime >= effectEnd;
+  if (snapshot.state === "playing" && !isComplete) {
+    animation.play();
+  } else {
+    animation.pause();
+  }
+}
+
+export function useWebAnimationController<TElement extends Element>(
+  forwardedRef: ForwardedRef<PlaybackAnimationController>,
+  createAnimation: (element: TElement) => Animation,
+): RefCallback<TElement> {
+  const animationRef = useRef<Animation | null>(null);
+  const snapshotRef = useRef<PlaybackSnapshot | null>(null);
+
+  useImperativeHandle(
+    forwardedRef,
+    () => ({
+      synchronize(snapshot) {
+        snapshotRef.current = snapshot;
+        if (animationRef.current) {
+          synchronizeAnimation(animationRef.current, snapshot);
+        }
+      },
+    }),
+    [],
+  );
+
+  return useCallback(
+    (element: TElement | null) => {
+      if (!element) return;
+
+      const animation = createAnimation(element);
+      animation.pause();
+      animationRef.current = animation;
+      if (snapshotRef.current) {
+        synchronizeAnimation(animation, snapshotRef.current);
+      }
+
+      void animation.ready
+        .then(() => {
+          if (animationRef.current === animation && snapshotRef.current) {
+            synchronizeAnimation(animation, snapshotRef.current);
+          }
+        })
+        .catch((error: unknown) => {
+          if (!(error instanceof DOMException && error.name === "AbortError")) {
+            console.error("Web animation failed to become ready", error);
+          }
+        });
+
+      return () => {
+        if (animationRef.current === animation) {
+          animationRef.current = null;
+        }
+        animation.cancel();
+      };
+    },
+    [createAnimation],
+  );
+}

--- a/packages/jukebox/src/hooks/useWebAnimationController.ts
+++ b/packages/jukebox/src/hooks/useWebAnimationController.ts
@@ -2,6 +2,7 @@ import type { ForwardedRef, RefCallback } from "react";
 import { useCallback, useImperativeHandle, useRef } from "react";
 import type { PlaybackAnimationController, PlaybackSnapshot } from "./types";
 
+/** Apply a media snapshot to a Web Animation without replaying a completed one. */
 function synchronizeAnimation(
   animation: Animation,
   snapshot: PlaybackSnapshot,
@@ -20,6 +21,13 @@ function synchronizeAnimation(
   }
 }
 
+/**
+ * Bind a Web Animation to an imperative media playback controller.
+ *
+ * The returned ref callback creates one animation for the mounted element,
+ * applies the latest snapshot again after the animation becomes ready, and
+ * cancels the animation during ref cleanup or unmount.
+ */
 export function useWebAnimationController<TElement extends Element>(
   forwardedRef: ForwardedRef<PlaybackAnimationController>,
   createAnimation: (element: TElement) => Animation,

--- a/packages/jukebox/tests/browser/fixture/index.html
+++ b/packages/jukebox/tests/browser/fixture/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Lyrics animation lifecycle fixture</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/packages/jukebox/tests/browser/fixture/src/main.tsx
+++ b/packages/jukebox/tests/browser/fixture/src/main.tsx
@@ -1,0 +1,184 @@
+import {
+  forwardRef,
+  StrictMode,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from "react";
+import { createRoot } from "react-dom/client";
+import gsap from "gsap";
+import { usePlayerLyricsState } from "../../../../src/hooks/usePlayerLyricsState";
+import { readPlaybackSnapshot } from "../../../../src/hooks/useMediaClock";
+import { useTrackwiseTimelineControl } from "../../../../src/hooks/useTrackwiseTimelineControl";
+import type { PlaybackAnimationController } from "../../../../src/hooks/types";
+import { useWebAnimationController } from "../../../../src/hooks/useWebAnimationController";
+
+const AnimatedNode = forwardRef<
+  PlaybackAnimationController,
+  { version: number }
+>(function AnimatedNode({ version }, ref) {
+  const createAnimation = useCallback(
+    (element: HTMLSpanElement) =>
+      element.animate([{ opacity: 0 }, { opacity: 1 }], {
+        duration: 10_000,
+        fill: "both",
+        id: `waapi-${version}`,
+      }),
+    [version],
+  );
+  const animationRef = useWebAnimationController(ref, createAnimation);
+  return (
+    <span data-testid="waapi-target" ref={animationRef}>
+      animated
+    </span>
+  );
+});
+
+function App() {
+  const transportRef = useRef({
+    currentTime: 0,
+    duration: 30,
+    paused: true,
+    playbackRate: 1,
+  });
+  const playerRef = useRef<HTMLAudioElement>(null!);
+  const bindPlayer = useCallback((player: HTMLAudioElement | null) => {
+    playerRef.current = player as HTMLAudioElement;
+    if (!player) return;
+    Object.defineProperties(player, {
+      currentTime: {
+        configurable: true,
+        get: () => transportRef.current.currentTime,
+        set: (value: number) => {
+          transportRef.current.currentTime = value;
+        },
+      },
+      duration: {
+        configurable: true,
+        get: () => transportRef.current.duration,
+      },
+      ended: {
+        configurable: true,
+        get: () => false,
+      },
+      paused: {
+        configurable: true,
+        get: () => transportRef.current.paused,
+      },
+      playbackRate: {
+        configurable: true,
+        get: () => transportRef.current.playbackRate,
+        set: (value: number) => {
+          transportRef.current.playbackRate = value;
+        },
+      },
+      readyState: {
+        configurable: true,
+        get: () => HTMLMediaElement.HAVE_ENOUGH_DATA,
+      },
+    });
+  }, []);
+
+  const { currentFrame, playerState } = usePlayerLyricsState(
+    [
+      { start: 1, data: "first" },
+      { start: 5, data: "second" },
+      { start: 9, data: "third" },
+    ],
+    playerRef,
+  );
+  const [mounted, setMounted] = useState(false);
+  const [version, setVersion] = useState(1);
+  const animationControllerRef = useRef<PlaybackAnimationController>(null);
+
+  useEffect(() => {
+    const player = playerRef.current;
+    if (mounted && player) {
+      animationControllerRef.current?.synchronize(readPlaybackSnapshot(player));
+    }
+  }, [currentFrame, mounted, playerState]);
+
+  const gsapTargetRef = useRef<HTMLDivElement>(null);
+  const [timeline, setTimeline] = useState<gsap.core.Timeline | null>(null);
+  useLayoutEffect(() => {
+    const target = gsapTargetRef.current;
+    if (!target) return;
+    const nextTimeline = gsap
+      .timeline({ paused: true })
+      .fromTo(target, { x: 0 }, { x: 100, duration: 10, ease: "none" }, 0);
+    setTimeline(nextTimeline);
+    return () => nextTimeline.kill();
+  }, []);
+  useTrackwiseTimelineControl(playerRef, playerState, timeline);
+
+  const dispatch = (event: string) => {
+    playerRef.current.dispatchEvent(new Event(event));
+  };
+  const seek = (currentTime: number) => {
+    transportRef.current.currentTime = currentTime;
+    dispatch("seeking");
+    dispatch("seeked");
+  };
+
+  return (
+    <main>
+      <audio ref={bindPlayer} />
+      <output data-testid="frame">{currentFrame?.data ?? "none"}</output>
+      <button type="button" onClick={() => seek(6)}>
+        seek-six
+      </button>
+      <button type="button" onClick={() => seek(0.5)}>
+        seek-before
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          transportRef.current.paused = false;
+          dispatch("play");
+        }}
+      >
+        play
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          transportRef.current.paused = true;
+          dispatch("pause");
+        }}
+      >
+        pause
+      </button>
+      <button
+        type="button"
+        onClick={() => {
+          transportRef.current.playbackRate = 2;
+          dispatch("ratechange");
+        }}
+      >
+        rate-two
+      </button>
+      <button type="button" onClick={() => setMounted((value) => !value)}>
+        toggle-animation
+      </button>
+      <button type="button" onClick={() => setVersion((value) => value + 1)}>
+        replace-animation
+      </button>
+      {mounted && (
+        <AnimatedNode ref={animationControllerRef} version={version} />
+      )}
+      <div
+        data-testid="gsap-target"
+        ref={gsapTargetRef}
+        style={{ width: 10, height: 10 }}
+      />
+    </main>
+  );
+}
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/packages/jukebox/tests/browser/specs/animation-lifecycle.spec.ts
+++ b/packages/jukebox/tests/browser/specs/animation-lifecycle.spec.ts
@@ -1,0 +1,59 @@
+import { expect, test } from "@playwright/test";
+
+test("synchronizes late mounts, seeks, rates, and replacements", async ({
+  page,
+}) => {
+  const pageErrors: Error[] = [];
+  page.on("pageerror", (error) => pageErrors.push(error));
+  await page.goto("/");
+
+  await page.getByRole("button", { name: "seek-six" }).click();
+  await expect(page.getByTestId("frame")).toHaveText("second");
+  await expect
+    .poll(() =>
+      page
+        .getByTestId("gsap-target")
+        .evaluate((element) => getComputedStyle(element).transform),
+    )
+    .not.toBe("none");
+
+  await page.getByRole("button", { name: "toggle-animation" }).click();
+  const animationState = () =>
+    page.getByTestId("waapi-target").evaluate((element) => {
+      const animations = element.getAnimations();
+      return {
+        count: animations.length,
+        currentTime: animations[0]?.currentTime,
+        id: animations[0]?.id,
+        playbackRate: animations[0]?.playbackRate,
+        playState: animations[0]?.playState,
+      };
+    });
+  await expect.poll(async () => (await animationState()).count).toBe(1);
+  await expect
+    .poll(async () => Number((await animationState()).currentTime))
+    .toBeCloseTo(6000, -1);
+
+  await page.getByRole("button", { name: "rate-two" }).click();
+  await expect.poll(async () => (await animationState()).playbackRate).toBe(2);
+
+  await page.getByRole("button", { name: "play", exact: true }).click();
+  await expect
+    .poll(async () => (await animationState()).playState)
+    .toBe("running");
+  await page.getByRole("button", { name: "pause", exact: true }).click();
+  await expect
+    .poll(async () => (await animationState()).playState)
+    .toBe("paused");
+
+  await page.getByRole("button", { name: "replace-animation" }).click();
+  await expect.poll(async () => (await animationState()).id).toBe("waapi-2");
+  await expect.poll(async () => (await animationState()).count).toBe(1);
+  await expect
+    .poll(async () => Number((await animationState()).currentTime))
+    .toBeCloseTo(6000, -1);
+
+  await page.getByRole("button", { name: "seek-before" }).click();
+  await expect(page.getByTestId("frame")).toHaveText("none");
+  expect(pageErrors).toEqual([]);
+});

--- a/packages/jukebox/tests/browser/vite.config.ts
+++ b/packages/jukebox/tests/browser/vite.config.ts
@@ -1,0 +1,15 @@
+import path from "node:path";
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  root: path.resolve(import.meta.dirname, "fixture"),
+  plugins: [react()],
+  server: {
+    port: 4173,
+    strictPort: true,
+    fs: {
+      allow: [path.resolve(import.meta.dirname, "../..")],
+    },
+  },
+});

--- a/packages/lyricova/next-env.d.ts
+++ b/packages/lyricova/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Summary

- replace TextTrack cue scheduling and ad hoc media-time calculations with a shared `currentTime`-based media clock
- add lifecycle-safe WAAPI and GSAP controllers, then migrate public and dashboard lyrics animations
- synchronize seeks, buffering, playback-rate changes, late mounts, virtualization, and Strict Mode ref replay
- document the animation timing architecture and add Chromium/Firefox Playwright coverage

## Validation

- `npm run typecheck -w @lyricova/jukebox`
- `npm run lint -w @lyricova/jukebox -- --quiet`
- `npm test -w @lyricova/jukebox`
- `npm run test:browser -w @lyricova/jukebox`