### PR TITLE
feat(jukebox): use native lyrics scrolling

### DIFF
--- a/packages/jukebox/src/components/public/lyrics/components/LyricsVirtualizer.tsx
+++ b/packages/jukebox/src/components/public/lyrics/components/LyricsVirtualizer.tsx
@@ -1,5 +1,6 @@
 import type React from "react";
 import { useCallback, useEffect, useRef } from "react";
+import { cn } from "@lyricova/components/utils";
 import type { LyricsKitLyricsLine } from "@lyricova/components/gql/schema";
 import {
   type LyricsSegment,
@@ -16,6 +17,7 @@ export interface RowRendererProps<T> {
   segment: LyricsSegment;
   isActive?: boolean;
   isActiveScroll?: boolean;
+  isUserScrolling?: boolean;
   ref?: React.Ref<HTMLDivElement>;
   top: number;
   transLang?: string;
@@ -36,6 +38,7 @@ export interface LyricsVirtualizerProps<
   alignAnchor?: number;
   containerAs?: TELement;
   containerProps?: React.ComponentProps<TELement>;
+  viewportClassName?: string;
 }
 
 /**
@@ -52,6 +55,7 @@ export function LyricsVirtualizer({
   alignAnchor = 0.5,
   containerAs: ContainerAs = "div",
   containerProps = {},
+  viewportClassName,
 }: LyricsVirtualizerProps<LyricsKitLyricsLine>) {
   const containerRef = useRef<HTMLDivElement>(null);
 
@@ -93,6 +97,7 @@ export function LyricsVirtualizer({
       top,
       rowRefHandler,
       isActiveScroll,
+      isUserScrolling,
     }: VirtualizerRowRenderProps) =>
       rowRenderer({
         row: rows[index]!,
@@ -103,6 +108,7 @@ export function LyricsVirtualizer({
         top,
         absoluteIndex,
         isActiveScroll,
+        isUserScrolling,
         isActive: activeSegments?.includes(index) ?? false,
         animationRef: setRef(index),
         onClick: () => {
@@ -115,7 +121,13 @@ export function LyricsVirtualizer({
     [activeSegments, playerRef, rowRenderer, rows, segments, setRef],
   );
 
-  const { renderedRows, isActiveScroll } = useLyricsVirtualizer({
+  const {
+    renderedRows,
+    scrollContentHeight,
+    scrollViewportHeight,
+    isActiveScroll,
+    isUserScrolling,
+  } = useLyricsVirtualizer({
     containerRef: containerRef as React.RefObject<HTMLDivElement>,
     startRow,
     endRow,
@@ -127,12 +139,25 @@ export function LyricsVirtualizer({
   });
 
   return (
-    <ContainerAs
-      ref={containerRef}
-      isActiveScroll={isActiveScroll}
-      {...containerProps}
-    >
-      {renderedRows}
+    <ContainerAs {...containerProps}>
+      <div
+        ref={containerRef}
+        className="no-scrollbar size-full touch-pan-y overflow-x-hidden overflow-y-auto overscroll-y-contain"
+        data-active-scroll={isActiveScroll}
+        data-user-scrolling={isUserScrolling}
+      >
+        <div
+          className="relative w-full"
+          style={{ height: scrollContentHeight }}
+        >
+          <div
+            className={cn("sticky top-0 w-full", viewportClassName)}
+            style={{ height: scrollViewportHeight }}
+          >
+            {renderedRows}
+          </div>
+        </div>
+      </div>
     </ContainerAs>
   );
 }

--- a/packages/jukebox/src/components/public/lyrics/components/useLyricsVirtualizer.tsx
+++ b/packages/jukebox/src/components/public/lyrics/components/useLyricsVirtualizer.tsx
@@ -10,6 +10,7 @@ export interface VirtualizerRowRenderProps {
   absoluteIndex: number;
   top: number;
   isActiveScroll: boolean;
+  isUserScrolling: boolean;
   rowRefHandler: (el: HTMLElement) => void;
 }
 
@@ -42,15 +43,16 @@ export function useLyricsVirtualizer({
     containerSize,
     rowCount,
   });
-  const { scrollOffset, isActiveScroll } = useScrollOffset({
-    containerRef,
-    containerSize,
-    rowAccumulateHeight,
-    startRow,
-    endRow,
-    align,
-    alignAnchor,
-  });
+  const { scrollOffset, scrollContentHeight, isActiveScroll, isUserScrolling } =
+    useScrollOffset({
+      containerRef,
+      containerSize,
+      rowAccumulateHeight,
+      startRow,
+      endRow,
+      align,
+      alignAnchor,
+    });
   const { renderStartRow, renderEndRow } = useRenderRange({
     scrollOffset,
     rowAccumulateHeight,
@@ -67,6 +69,7 @@ export function useLyricsVirtualizer({
             i < startRow ? i - startRow : i >= endRow ? i - endRow + 1 : 0,
           top: rowAccumulateHeight[i] - scrollOffset,
           isActiveScroll,
+          isUserScrolling,
           rowRefHandler: rowRefHandler(i),
         }),
       );
@@ -81,8 +84,15 @@ export function useLyricsVirtualizer({
     rowAccumulateHeight,
     scrollOffset,
     isActiveScroll,
+    isUserScrolling,
     rowRefHandler,
   ]);
 
-  return { renderedRows, isActiveScroll };
+  return {
+    renderedRows,
+    scrollContentHeight,
+    scrollViewportHeight: containerSize.height,
+    isActiveScroll,
+    isUserScrolling,
+  };
 }

--- a/packages/jukebox/src/components/public/lyrics/components/useScrollOffset.spec.tsx
+++ b/packages/jukebox/src/components/public/lyrics/components/useScrollOffset.spec.tsx
@@ -6,12 +6,20 @@ import { useScrollOffset } from "./useScrollOffset";
 
 const rowAccumulateHeight = [0, 100, 200, 300];
 
-function Harness({ startRow, endRow }: { startRow: number; endRow: number }) {
+function Harness({
+  startRow,
+  endRow,
+  containerHeight = 200,
+}: {
+  startRow: number;
+  endRow: number;
+  containerHeight?: number;
+}) {
   const containerRef = useRef<HTMLDivElement>(null);
   const { scrollOffset, scrollContentHeight, isActiveScroll, isUserScrolling } =
     useScrollOffset({
       containerRef: containerRef as RefObject<HTMLDivElement>,
-      containerSize: { width: 400, height: 200 },
+      containerSize: { width: 400, height: containerHeight },
       rowAccumulateHeight,
       startRow,
       endRow,
@@ -74,5 +82,34 @@ describe("useScrollOffset", () => {
     act(() => fireEvent.scroll(scroller));
     expect(scroller.dataset.activeScroll).toBe("false");
     expect(scroller.dataset.userScrolling).toBe("false");
+  });
+
+  it("rebases native scrollTop when the viewport resizes during browsing", () => {
+    const view = render(
+      <Harness startRow={1} endRow={2} containerHeight={200} />,
+    );
+    const scroller = view.getByTestId("scroller");
+
+    act(() => {
+      scroller.scrollTop = 210;
+      fireEvent.scroll(scroller);
+      vi.advanceTimersByTime(151);
+    });
+    expect(scroller.dataset.scrollOffset).toBe("110");
+    expect(scroller.dataset.activeScroll).toBe("true");
+    expect(scroller.dataset.userScrolling).toBe("false");
+
+    view.rerender(<Harness startRow={1} endRow={2} containerHeight={300} />);
+    expect(scroller.dataset.scrollOffset).toBe("100");
+    expect(scroller.scrollTop).toBe(250);
+
+    act(() => fireEvent.scroll(scroller));
+    expect(scroller.dataset.scrollOffset).toBe("100");
+    expect(scroller.dataset.userScrolling).toBe("false");
+
+    act(() => vi.advanceTimersByTime(4849));
+    expect(scroller.dataset.activeScroll).toBe("false");
+    expect(scroller.dataset.scrollOffset).toBe("0");
+    expect(scroller.scrollTop).toBe(150);
   });
 });

--- a/packages/jukebox/src/components/public/lyrics/components/useScrollOffset.spec.tsx
+++ b/packages/jukebox/src/components/public/lyrics/components/useScrollOffset.spec.tsx
@@ -1,0 +1,78 @@
+import { act, fireEvent, render } from "@testing-library/react";
+import type { RefObject } from "react";
+import { useRef } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useScrollOffset } from "./useScrollOffset";
+
+const rowAccumulateHeight = [0, 100, 200, 300];
+
+function Harness({ startRow, endRow }: { startRow: number; endRow: number }) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const { scrollOffset, scrollContentHeight, isActiveScroll, isUserScrolling } =
+    useScrollOffset({
+      containerRef: containerRef as RefObject<HTMLDivElement>,
+      containerSize: { width: 400, height: 200 },
+      rowAccumulateHeight,
+      startRow,
+      endRow,
+      align: "center",
+      alignAnchor: 0.5,
+    });
+
+  return (
+    <div
+      ref={containerRef}
+      data-testid="scroller"
+      data-scroll-offset={scrollOffset}
+      data-scroll-content-height={scrollContentHeight}
+      data-active-scroll={isActiveScroll}
+      data-user-scrolling={isUserScrolling}
+    />
+  );
+}
+
+describe("useScrollOffset", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("uses native scrollTop during user scrolling and resumes auto-follow", () => {
+    const view = render(<Harness startRow={1} endRow={2} />);
+    const scroller = view.getByTestId("scroller");
+
+    expect(scroller.dataset.scrollOffset).toBe("50");
+    expect(scroller.dataset.scrollContentHeight).toBe("450");
+    expect(scroller.scrollTop).toBe(150);
+
+    act(() => {
+      vi.advanceTimersByTime(20);
+      scroller.scrollTop = 210;
+      fireEvent.scroll(scroller);
+    });
+
+    expect(scroller.dataset.scrollOffset).toBe("110");
+    expect(scroller.dataset.activeScroll).toBe("true");
+    expect(scroller.dataset.userScrolling).toBe("true");
+
+    act(() => vi.advanceTimersByTime(151));
+    expect(scroller.dataset.scrollOffset).toBe("110");
+    expect(scroller.dataset.activeScroll).toBe("true");
+    expect(scroller.dataset.userScrolling).toBe("false");
+
+    view.rerender(<Harness startRow={2} endRow={3} />);
+    expect(scroller.dataset.scrollOffset).toBe("110");
+
+    act(() => vi.advanceTimersByTime(5000));
+    expect(scroller.dataset.scrollOffset).toBe("150");
+    expect(scroller.dataset.activeScroll).toBe("false");
+    expect(scroller.scrollTop).toBe(250);
+
+    act(() => fireEvent.scroll(scroller));
+    expect(scroller.dataset.activeScroll).toBe("false");
+    expect(scroller.dataset.userScrolling).toBe("false");
+  });
+});

--- a/packages/jukebox/src/components/public/lyrics/components/useScrollOffset.tsx
+++ b/packages/jukebox/src/components/public/lyrics/components/useScrollOffset.tsx
@@ -116,6 +116,16 @@ export function useScrollOffset({
     }, AUTO_FOLLOW_RESUME_DELAY);
   }, []);
 
+  const setProgrammaticScrollTop = useCallback(
+    (container: HTMLDivElement, scrollTop: number) => {
+      programmaticScrollTopRef.current = scrollTop;
+      if (Math.abs(container.scrollTop - scrollTop) >= 0.5) {
+        container.scrollTop = scrollTop;
+      }
+    },
+    [],
+  );
+
   useEffect(() => {
     const container = containerRef.current;
     if (!container) return;
@@ -123,10 +133,10 @@ export function useScrollOffset({
     function scrollListener() {
       const programmaticScrollTop = programmaticScrollTopRef.current;
       if (
-        activeScrollOffsetRef.current === undefined &&
         programmaticScrollTop !== undefined &&
         Math.abs(container.scrollTop - programmaticScrollTop) < 0.5
       ) {
+        programmaticScrollTopRef.current = undefined;
         return;
       }
       programmaticScrollTopRef.current = undefined;
@@ -141,19 +151,36 @@ export function useScrollOffset({
 
   useLayoutEffect(() => {
     const container = containerRef.current;
-    if (!container || activeScrollOffset !== undefined) return;
+    const activeOffset = activeScrollOffsetRef.current;
+    if (!container || activeOffset === undefined) return;
 
-    const nextScrollTop = targetScrollOffset - scrollOffsetMin;
-    programmaticScrollTopRef.current = nextScrollTop;
-    if (Math.abs(container.scrollTop - nextScrollTop) >= 0.5) {
-      container.scrollTop = nextScrollTop;
+    const nextActiveOffset = clamp(
+      activeOffset,
+      scrollOffsetMin,
+      scrollOffsetMax,
+    );
+    if (nextActiveOffset !== activeOffset) {
+      activeScrollOffsetRef.current = nextActiveOffset;
+      setActiveScrollOffset(nextActiveOffset);
     }
-    programmaticScrollTopRef.current = container.scrollTop;
+    setProgrammaticScrollTop(container, nextActiveOffset - scrollOffsetMin);
   }, [
-    activeScrollOffset,
     containerRef,
     scrollOffsetMax,
     scrollOffsetMin,
+    setProgrammaticScrollTop,
+  ]);
+
+  useLayoutEffect(() => {
+    const container = containerRef.current;
+    if (!container || activeScrollOffset !== undefined) return;
+
+    setProgrammaticScrollTop(container, targetScrollOffset - scrollOffsetMin);
+  }, [
+    activeScrollOffset,
+    containerRef,
+    scrollOffsetMin,
+    setProgrammaticScrollTop,
     targetScrollOffset,
   ]);
 

--- a/packages/jukebox/src/components/public/lyrics/components/useScrollOffset.tsx
+++ b/packages/jukebox/src/components/public/lyrics/components/useScrollOffset.tsx
@@ -1,6 +1,19 @@
-import _ from "lodash";
 import type { RefObject } from "react";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+
+const AUTO_FOLLOW_RESUME_DELAY = 5000;
+const SCROLL_IDLE_DELAY = 150;
+
+function clamp(value: number, min: number, max: number) {
+  return Math.max(min, Math.min(max, value));
+}
 
 export function useScrollOffset({
   containerRef,
@@ -22,116 +35,145 @@ export function useScrollOffset({
   const [activeScrollOffset, setActiveScrollOffset] = useState<
     number | undefined
   >(undefined);
+  const [isUserScrolling, setIsUserScrolling] = useState(false);
 
   const containerHeight = containerSize.height;
   const anchorOffset = containerHeight * alignAnchor;
-  const scorllOffsetMin = -anchorOffset;
-  const scrollOffsetMax = (rowAccumulateHeight.at(-2) ?? 0) + scorllOffsetMin;
+  const scrollOffsetMin = -anchorOffset;
+  const lastRowStart = rowAccumulateHeight.at(-2) ?? 0;
+  const contentHeight = rowAccumulateHeight.at(-1) ?? 0;
+  const lastAlignedOffset =
+    align === "start"
+      ? lastRowStart
+      : align === "center"
+        ? (lastRowStart + contentHeight) / 2
+        : contentHeight;
+  const scrollOffsetMax = Math.max(
+    scrollOffsetMin,
+    lastAlignedOffset - anchorOffset,
+  );
 
-  const scrollOffset = useMemo(() => {
+  const targetScrollOffset = useMemo(() => {
     const startOffset = rowAccumulateHeight[startRow];
     const endOffset = rowAccumulateHeight[endRow];
 
-    let newScrollOffset = 0;
+    let nextScrollOffset = 0;
     if (align === "start") {
-      newScrollOffset = startOffset - anchorOffset;
+      nextScrollOffset = startOffset - anchorOffset;
     } else if (align === "center") {
-      newScrollOffset = (startOffset + endOffset) / 2 - anchorOffset;
+      nextScrollOffset = (startOffset + endOffset) / 2 - anchorOffset;
     } else if (align === "end") {
-      newScrollOffset = endOffset - anchorOffset;
+      nextScrollOffset = endOffset - anchorOffset;
     }
-    return Math.round(newScrollOffset);
-  }, [rowAccumulateHeight, startRow, endRow, align, anchorOffset]);
-  const scrollOffsetRef = useRef(scrollOffset);
-  scrollOffsetRef.current = scrollOffset;
-
-  const debounceReset = useCallback(
-    _.debounce(() => setActiveScrollOffset(undefined), 5000),
-    [setActiveScrollOffset],
-  );
-
-  useEffect(() => {
-    const bottom = rowAccumulateHeight.at(-1) ?? 0;
-    let direction: "up" | "down" | "none" = "none";
-    let startTouchPosY = 0;
-    let lastMoveY = 0;
-    function wheelListener(event: WheelEvent) {
-      setActiveScrollOffset((v) => {
-        const base = v !== undefined ? v : scrollOffsetRef.current;
-        let result = base;
-        if (event.deltaMode === event.DOM_DELTA_PIXEL) {
-          result += event.deltaY;
-        } else {
-          result += event.deltaY * 50;
-        }
-        // TODO: fix scroll bound
-        return Math.max(scorllOffsetMin, Math.min(scrollOffsetMax, result));
-      });
-      debounceReset();
-    }
-    function touchStartListener(event: TouchEvent) {
-      // event.preventDefault();
-      // startScrollY = this.scrollOffset;
-      startTouchPosY = event.touches[0].screenY;
-      lastMoveY = startTouchPosY;
-    }
-
-    function touchMoveListener(event: TouchEvent) {
-      event.preventDefault();
-      const touchScreenY = event.touches[0].screenY;
-      const delta = touchScreenY - startTouchPosY;
-      const lastDelta = touchScreenY - lastMoveY;
-      const targetDirection =
-        lastDelta > 0 ? "down" : lastDelta < 0 ? "up" : "none";
-      if (direction !== targetDirection) {
-        direction = targetDirection;
-        startTouchPosY = touchScreenY;
-      } else {
-        // TODO: fix scroll bound
-        setActiveScrollOffset((v) =>
-          Math.max(0, Math.min(bottom, (v ?? scrollOffsetRef.current) - delta)),
-        );
-      }
-      debounceReset();
-      lastMoveY = touchScreenY;
-    }
-
-    function touchEndListener(_event: TouchEvent) {
-      // event.preventDefault();
-      debounceReset();
-    }
-
-    const container = containerRef.current;
-    if (container) {
-      container.addEventListener("wheel", wheelListener, { passive: true });
-      container.addEventListener("touchstart", touchStartListener, {
-        passive: false,
-      });
-      container.addEventListener("touchmove", touchMoveListener, {
-        passive: false,
-      });
-      container.addEventListener("touchend", touchEndListener, {
-        passive: false,
-      });
-      return () => {
-        container?.removeEventListener("wheel", wheelListener);
-        container?.removeEventListener("touchstart", touchStartListener);
-        container?.removeEventListener("touchmove", touchMoveListener);
-        container?.removeEventListener("touchend", touchEndListener);
-      };
-    }
+    return clamp(
+      Math.round(nextScrollOffset),
+      scrollOffsetMin,
+      scrollOffsetMax,
+    );
   }, [
-    containerRef,
-    debounceReset,
+    align,
+    anchorOffset,
+    endRow,
     rowAccumulateHeight,
-    scorllOffsetMin,
     scrollOffsetMax,
-    setActiveScrollOffset,
+    scrollOffsetMin,
+    startRow,
   ]);
 
+  const boundsRef = useRef({
+    min: scrollOffsetMin,
+    max: scrollOffsetMax,
+  });
+  boundsRef.current = { min: scrollOffsetMin, max: scrollOffsetMax };
+
+  const activeScrollOffsetRef = useRef(activeScrollOffset);
+  activeScrollOffsetRef.current = activeScrollOffset;
+  const programmaticScrollTopRef = useRef<number | undefined>(undefined);
+  const autoFollowTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined,
+  );
+  const scrollIdleTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined,
+  );
+
+  const updateFromNativeScroll = useCallback((nativeScrollTop: number) => {
+    const { min, max } = boundsRef.current;
+    const nextScrollOffset = clamp(nativeScrollTop + min, min, max);
+    activeScrollOffsetRef.current = nextScrollOffset;
+    setActiveScrollOffset(nextScrollOffset);
+    setIsUserScrolling(true);
+
+    clearTimeout(scrollIdleTimerRef.current);
+    scrollIdleTimerRef.current = setTimeout(
+      () => setIsUserScrolling(false),
+      SCROLL_IDLE_DELAY,
+    );
+
+    clearTimeout(autoFollowTimerRef.current);
+    autoFollowTimerRef.current = setTimeout(() => {
+      activeScrollOffsetRef.current = undefined;
+      setActiveScrollOffset(undefined);
+    }, AUTO_FOLLOW_RESUME_DELAY);
+  }, []);
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    function scrollListener() {
+      const programmaticScrollTop = programmaticScrollTopRef.current;
+      if (
+        activeScrollOffsetRef.current === undefined &&
+        programmaticScrollTop !== undefined &&
+        Math.abs(container.scrollTop - programmaticScrollTop) < 0.5
+      ) {
+        return;
+      }
+      programmaticScrollTopRef.current = undefined;
+      updateFromNativeScroll(container.scrollTop);
+    }
+
+    container.addEventListener("scroll", scrollListener, { passive: true });
+    return () => {
+      container.removeEventListener("scroll", scrollListener);
+    };
+  }, [containerRef, updateFromNativeScroll]);
+
+  useLayoutEffect(() => {
+    const container = containerRef.current;
+    if (!container || activeScrollOffset !== undefined) return;
+
+    const nextScrollTop = targetScrollOffset - scrollOffsetMin;
+    programmaticScrollTopRef.current = nextScrollTop;
+    if (Math.abs(container.scrollTop - nextScrollTop) >= 0.5) {
+      container.scrollTop = nextScrollTop;
+    }
+    programmaticScrollTopRef.current = container.scrollTop;
+  }, [
+    activeScrollOffset,
+    containerRef,
+    scrollOffsetMax,
+    scrollOffsetMin,
+    targetScrollOffset,
+  ]);
+
+  useEffect(
+    () => () => {
+      clearTimeout(autoFollowTimerRef.current);
+      clearTimeout(scrollIdleTimerRef.current);
+    },
+    [],
+  );
+
+  const scrollOffset =
+    activeScrollOffset === undefined
+      ? targetScrollOffset
+      : clamp(activeScrollOffset, scrollOffsetMin, scrollOffsetMax);
+
   return {
-    scrollOffset:
-      activeScrollOffset === undefined ? scrollOffset : activeScrollOffset,
+    scrollOffset,
+    scrollContentHeight: containerHeight + scrollOffsetMax - scrollOffsetMin,
     isActiveScroll: activeScrollOffset !== undefined,
+    isUserScrolling,
   };
 }

--- a/packages/jukebox/src/components/public/lyrics/plain.tsx
+++ b/packages/jukebox/src/components/public/lyrics/plain.tsx
@@ -83,6 +83,7 @@ const InnerRowRenderer = forwardRef<
       onClick,
       transLang,
       absoluteIndex,
+      isUserScrolling,
     },
     ref,
   ) => {
@@ -91,8 +92,8 @@ const InnerRowRenderer = forwardRef<
     }));
 
     useEffect(() => {
-      api.start({ to: { y: top } });
-    }, [api, top]);
+      api.start({ to: { y: top }, immediate: isUserScrolling });
+    }, [api, isUserScrolling, top]);
 
     return (
       <animated.div
@@ -131,7 +132,8 @@ const RowRenderer = memo(
     prev.transLang === next.transLang &&
     prev.isActive === next.isActive &&
     prev.absoluteIndex === next.absoluteIndex &&
-    prev.isActiveScroll === next.isActiveScroll,
+    prev.isActiveScroll === next.isActiveScroll &&
+    prev.isUserScrolling === next.isUserScrolling,
 );
 
 interface Props {
@@ -148,8 +150,9 @@ export function PlainLyrics({ lyrics, transLangIdx }: Props) {
       containerAs="div"
       containerProps={{
         className:
-          "p-4 w-full h-full overflow-hidden relative text-justify mask-y-from-70% mask-y-to-100%",
+          "size-full overflow-hidden relative text-justify mask-y-from-70% mask-y-to-100%",
       }}
+      viewportClassName="p-4"
       align="center"
       alignAnchor={0.5}
     >

--- a/packages/jukebox/src/components/public/lyrics/ringoll/RowRenderer.tsx
+++ b/packages/jukebox/src/components/public/lyrics/ringoll/RowRenderer.tsx
@@ -36,6 +36,7 @@ const InnerRowRenderer = forwardRef<
       absoluteIndex,
       isActive,
       isActiveScroll,
+      isUserScrolling,
       animationRef,
       onClick,
       transLang,
@@ -62,8 +63,9 @@ const InnerRowRenderer = forwardRef<
             : `blur(${Math.abs(absoluteIndex) * 0.3}px)`,
         },
         delay,
+        immediate: isUserScrolling,
       });
-    }, [absoluteIndex, api, isActive, isActiveScroll, top]);
+    }, [absoluteIndex, api, isActive, isActiveScroll, isUserScrolling, top]);
 
     return (
       <animated.div
@@ -107,5 +109,6 @@ export const RowRenderer = memo(
     prev.transLang === next.transLang &&
     prev.isActive === next.isActive &&
     prev.absoluteIndex === next.absoluteIndex &&
-    prev.isActiveScroll === next.isActiveScroll,
+    prev.isActiveScroll === next.isActiveScroll &&
+    prev.isUserScrolling === next.isUserScrolling,
 );

--- a/packages/jukebox/src/components/public/lyrics/ringoll/ringoll.tsx
+++ b/packages/jukebox/src/components/public/lyrics/ringoll/ringoll.tsx
@@ -7,15 +7,11 @@ import { cn } from "@lyricova/components/utils";
 const RingollContainerDiv = (props: ComponentProps<"div">) => (
   <div
     {...props}
-    // Apply Tailwind classes for basic layout and padding
-    // Keep complex mask and transition properties as inline styles
-    // Attempt hover effect using arbitrary variants (may need adjustment)
     className={cn(
-      "relative p-4 px-8 size-full overflow-clip transition-[mask-image,var(--tw-mask-bottom-from-position)] duration-0",
+      "relative size-full overflow-clip transition-[mask-image,var(--tw-mask-bottom-from-position)] duration-0",
       "mask-t-from-[calc(100%_-_5em)] mask-t-to-100% mask-b-from-70% mask-b-to-100%",
       "hover:mask-b-from-100%",
     )}
-    style={{}}
   />
 );
 
@@ -31,7 +27,8 @@ export function RingollLyrics({ lyrics, transLangIdx }: Props) {
     <LyricsVirtualizer
       rows={lyrics.lines}
       estimatedRowHeight={20}
-      containerAs={RingollContainerDiv} // Use the new functional component
+      containerAs={RingollContainerDiv}
+      viewportClassName="p-4 px-8"
       align="start"
       alignAnchor={0.1}
     >

--- a/packages/jukebox/tests/browser/fixture/src/main.tsx
+++ b/packages/jukebox/tests/browser/fixture/src/main.tsx
@@ -18,10 +18,11 @@ import { useScrollOffset } from "../../../../src/components/public/lyrics/compon
 
 function NativeScrollHarness() {
   const containerRef = useRef<HTMLDivElement>(null);
+  const [containerHeight, setContainerHeight] = useState(200);
   const { scrollOffset, scrollContentHeight, isActiveScroll, isUserScrolling } =
     useScrollOffset({
       containerRef,
-      containerSize: { width: 300, height: 200 },
+      containerSize: { width: 300, height: containerHeight },
       rowAccumulateHeight: [0, 100, 200, 300],
       startRow: 1,
       endRow: 2,
@@ -30,28 +31,33 @@ function NativeScrollHarness() {
     });
 
   return (
-    <div
-      ref={containerRef}
-      data-testid="native-scroller"
-      data-active-scroll={isActiveScroll}
-      data-user-scrolling={isUserScrolling}
-      style={{
-        height: 200,
-        overflowY: "auto",
-        overscrollBehaviorY: "contain",
-        touchAction: "pan-y",
-        width: 300,
-      }}
-    >
-      <div style={{ height: scrollContentHeight, position: "relative" }}>
-        <div
-          data-testid="sticky-lyrics-viewport"
-          style={{ height: 200, position: "sticky", top: 0 }}
-        >
-          <output data-testid="native-scroll-offset">{scrollOffset}</output>
+    <>
+      <button type="button" onClick={() => setContainerHeight(300)}>
+        resize-native-scroller
+      </button>
+      <div
+        ref={containerRef}
+        data-testid="native-scroller"
+        data-active-scroll={isActiveScroll}
+        data-user-scrolling={isUserScrolling}
+        style={{
+          height: containerHeight,
+          overflowY: "auto",
+          overscrollBehaviorY: "contain",
+          touchAction: "pan-y",
+          width: 300,
+        }}
+      >
+        <div style={{ height: scrollContentHeight, position: "relative" }}>
+          <div
+            data-testid="sticky-lyrics-viewport"
+            style={{ height: containerHeight, position: "sticky", top: 0 }}
+          >
+            <output data-testid="native-scroll-offset">{scrollOffset}</output>
+          </div>
         </div>
       </div>
-    </div>
+    </>
   );
 }
 

--- a/packages/jukebox/tests/browser/fixture/src/main.tsx
+++ b/packages/jukebox/tests/browser/fixture/src/main.tsx
@@ -14,6 +14,46 @@ import { readPlaybackSnapshot } from "../../../../src/hooks/useMediaClock";
 import { useTrackwiseTimelineControl } from "../../../../src/hooks/useTrackwiseTimelineControl";
 import type { PlaybackAnimationController } from "../../../../src/hooks/types";
 import { useWebAnimationController } from "../../../../src/hooks/useWebAnimationController";
+import { useScrollOffset } from "../../../../src/components/public/lyrics/components/useScrollOffset";
+
+function NativeScrollHarness() {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const { scrollOffset, scrollContentHeight, isActiveScroll, isUserScrolling } =
+    useScrollOffset({
+      containerRef,
+      containerSize: { width: 300, height: 200 },
+      rowAccumulateHeight: [0, 100, 200, 300],
+      startRow: 1,
+      endRow: 2,
+      align: "center",
+      alignAnchor: 0.5,
+    });
+
+  return (
+    <div
+      ref={containerRef}
+      data-testid="native-scroller"
+      data-active-scroll={isActiveScroll}
+      data-user-scrolling={isUserScrolling}
+      style={{
+        height: 200,
+        overflowY: "auto",
+        overscrollBehaviorY: "contain",
+        touchAction: "pan-y",
+        width: 300,
+      }}
+    >
+      <div style={{ height: scrollContentHeight, position: "relative" }}>
+        <div
+          data-testid="sticky-lyrics-viewport"
+          style={{ height: 200, position: "sticky", top: 0 }}
+        >
+          <output data-testid="native-scroll-offset">{scrollOffset}</output>
+        </div>
+      </div>
+    </div>
+  );
+}
 
 const AnimatedNode = forwardRef<
   PlaybackAnimationController,
@@ -124,6 +164,7 @@ function App() {
 
   return (
     <main>
+      <NativeScrollHarness />
       <audio ref={bindPlayer} />
       <output data-testid="frame">{currentFrame?.data ?? "none"}</output>
       <button type="button" onClick={() => seek(6)}>

--- a/packages/jukebox/tests/browser/specs/animation-lifecycle.spec.ts
+++ b/packages/jukebox/tests/browser/specs/animation-lifecycle.spec.ts
@@ -28,6 +28,21 @@ test("uses native wheel scrolling behind a sticky lyrics viewport", async ({
   await expect
     .poll(() => viewport.evaluate((node) => node.getBoundingClientRect().top))
     .toBe(initialViewportTop);
+
+  await expect(scroller).toHaveAttribute("data-user-scrolling", "false");
+  const activeOffset = Number(
+    await page.getByTestId("native-scroll-offset").textContent(),
+  );
+  const resizedOffset = Math.min(activeOffset, 100);
+  await page.getByRole("button", { name: "resize-native-scroller" }).click();
+
+  await expect(page.getByTestId("native-scroll-offset")).toHaveText(
+    String(resizedOffset),
+  );
+  await expect
+    .poll(() => scroller.evaluate((node) => node.scrollTop))
+    .toBe(resizedOffset + 150);
+  await expect(scroller).toHaveAttribute("data-user-scrolling", "false");
 });
 
 test("synchronizes late mounts, seeks, rates, and replacements", async ({

--- a/packages/jukebox/tests/browser/specs/animation-lifecycle.spec.ts
+++ b/packages/jukebox/tests/browser/specs/animation-lifecycle.spec.ts
@@ -1,5 +1,35 @@
 import { expect, test } from "@playwright/test";
 
+test("uses native wheel scrolling behind a sticky lyrics viewport", async ({
+  page,
+}) => {
+  await page.goto("/");
+
+  const scroller = page.getByTestId("native-scroller");
+  const viewport = page.getByTestId("sticky-lyrics-viewport");
+  await expect
+    .poll(() => scroller.evaluate((node) => node.scrollTop))
+    .toBe(150);
+  const initialViewportTop = await viewport.evaluate(
+    (node) => node.getBoundingClientRect().top,
+  );
+
+  await scroller.hover();
+  await page.mouse.wheel(0, 60);
+
+  await expect
+    .poll(() => scroller.evaluate((node) => node.scrollTop))
+    .toBeGreaterThan(150);
+  const nativeScrollTop = await scroller.evaluate((node) => node.scrollTop);
+  await expect(page.getByTestId("native-scroll-offset")).toHaveText(
+    String(nativeScrollTop - 100),
+  );
+  await expect(scroller).toHaveAttribute("data-active-scroll", "true");
+  await expect
+    .poll(() => viewport.evaluate((node) => node.getBoundingClientRect().top))
+    .toBe(initialViewportTop);
+});
+
 test("synchronizes late mounts, seeks, rates, and replacements", async ({
   page,
 }) => {


### PR DESCRIPTION
## Summary
- replace manual wheel and touch delta handling with a native overflow scroll container
- keep virtualized lyrics in a sticky viewport and preserve the five-second manual browsing window
- make row springs immediate during active native scrolling, then restore Ringoll staggered transitions for playback auto-follow
- add unit and Chromium/Firefox browser regressions for native scroll behavior

## Validation
- `npm run test -w @lyricova/jukebox`
- `npm run typecheck -w @lyricova/jukebox`
- `npm run test:browser -w @lyricova/jukebox`
- targeted ESLint checks for changed files